### PR TITLE
Add set_false_math to false to solve accuracy issue for gelu test.

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1145,7 +1145,9 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         // perform static quantization on the programs
         migraphx::quantize_int8(prog, t_, quant_opts);
       }
-      prog.compile(t_);
+      migraphx::compile_options co;
+      co.set_fast_math(false);
+      prog.compile(t_, co);
       auto prog_output_shapes = prog.get_output_shapes();
       for (std::size_t i = 0; i < output_names.size(); ++i) {
         auto out_len = prog_output_shapes[i].lengths();
@@ -1263,7 +1265,9 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           migraphx::quantize_int8(prog, t, quant_opts);
         }
 
-        prog.compile(t);
+        migraphx::compile_options co;
+        co.set_fast_math(false);
+        prog.compile(t, co);
         mgx_state->prog = prog;
         param_shapes = prog.get_parameter_shapes();
         no_input_shape = false;


### PR DESCRIPTION
Patching in fast match disabled in the MIGraphX Compile stage in the MIGraphX EP

### Description
<!-- Describe your changes. -->

Allow the MIGraphX API to compile the program given to the EP to turn off fast math by default.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Fixes accuracy issue we're seeing with GELU parity tests. Without fast math disabled GELU will use a faster but less numerically stable version which trades speed for accuracy. 
