### PR TITLE
[MIGraphX EP] Set external data path option

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -53,10 +53,10 @@ struct MIGraphXFuncState {
 };
 
 // Logical device representation.
-class MIGraphXExecutionProvider final : public IExecutionProvider {
+class MIGraphXExecutionProvider : public IExecutionProvider {
  public:
   explicit MIGraphXExecutionProvider(const MIGraphXExecutionProviderInfo& info);
-  ~MIGraphXExecutionProvider() override;
+  ~MIGraphXExecutionProvider();
 
   Status Sync() const override;
 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -11,6 +11,7 @@
 
 #include <map>
 #include <unordered_map>
+#include <filesystem>
 
 namespace onnxruntime {
 
@@ -52,10 +53,10 @@ struct MIGraphXFuncState {
 };
 
 // Logical device representation.
-class MIGraphXExecutionProvider : public IExecutionProvider {
+class MIGraphXExecutionProvider final : public IExecutionProvider {
  public:
   explicit MIGraphXExecutionProvider(const MIGraphXExecutionProviderInfo& info);
-  ~MIGraphXExecutionProvider();
+  ~MIGraphXExecutionProvider() override;
 
   Status Sync() const override;
 
@@ -77,7 +78,6 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   void RegisterStreamHandlers(IStreamCommandHandleRegistry& stream_handle_registry, AllocatorMap& allocators) const override;
   OrtDevice GetOrtDeviceByMemType(OrtMemType mem_type) const override;
   std::vector<AllocatorPtr> CreatePreferredAllocators() override;
-  std::string GetModelParentPath() const;
 
   int GetDeviceId() const override { return info_.device_id; }
   ProviderOptions GetProviderOptions() const override {
@@ -101,7 +101,7 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   migraphx::target t_;
   OrtMutex mgx_mu_;
   hipStream_t stream_ = nullptr;
-  mutable char model_path_[4096] = {};  // Reserved for max path length
+  mutable std::filesystem::path model_path_;
 
   std::unordered_map<std::string, migraphx::program> map_progs_;
   std::unordered_map<std::string, std::string> map_onnx_string_;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -77,6 +77,7 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   void RegisterStreamHandlers(IStreamCommandHandleRegistry& stream_handle_registry, AllocatorMap& allocators) const override;
   OrtDevice GetOrtDeviceByMemType(OrtMemType mem_type) const override;
   std::vector<AllocatorPtr> CreatePreferredAllocators() override;
+  std::string GetModelParentPath() const;
 
   int GetDeviceId() const override { return info_.device_id; }
   ProviderOptions GetProviderOptions() const override {
@@ -100,6 +101,7 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   migraphx::target t_;
   OrtMutex mgx_mu_;
   hipStream_t stream_ = nullptr;
+  mutable char model_path_[4096] = {};  // Reserved for max path length
 
   std::unordered_map<std::string, migraphx::program> map_progs_;
   std::unordered_map<std::string, std::string> map_onnx_string_;


### PR DESCRIPTION
Set external data path before calling parse_onnx_buffer in case MIGraphX needs to read external data.

This change is needed in order for ORT Stable Diffusion pipeline (maybe some other models as well) to work with MIGraphX EP. It fails to compile unet model because it does not construct absolute path to the external file that is needed for compilation.
Note: This change depends on changes in AMDMIGraphX (PR: https://github.com/ROCm/AMDMIGraphX/pull/3191)