### PR TITLE
Remove CMP0144 for now as that requires cmake 3.27.0

### DIFF
--- a/cmake/onnxruntime_providers_migraphx.cmake
+++ b/cmake/onnxruntime_providers_migraphx.cmake
@@ -21,8 +21,8 @@
   # Add search paths for default rocm installation
   list(APPEND CMAKE_PREFIX_PATH /opt/rocm/hcc /opt/rocm/hip /opt/rocm)
 
-  find_package(hip)
-  find_package(migraphx PATHS ${AMD_MIGRAPHX_HOME})
+  # Suppress the warning about the small capitals of the package name - Enable when support to CMake 3.27.0 is used
+  # cmake_policy(SET CMP0144 NEW)
 
   find_package(miopen)
   find_package(rocblas)


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

Fixes issue with upstream requring CMake = 3.26.4 right now.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Keep things consistent with upstream onnxruntime
