### PR TITLE
Change python not be greater than in order to avoid auto pulling down…

### DIFF
--- a/requirements.txt.in
+++ b/requirements.txt.in
@@ -1,6 +1,6 @@
 coloredlogs
 flatbuffers
-numpy >= @Python_NumPy_VERSION@
+numpy == @Python_NumPy_VERSION@
 packaging
 protobuf
 sympy


### PR DESCRIPTION
… numpy 2.0 which seems to cause ABI breaks with some scripts and other tools during wheel installs

### Description
<!-- Describe your changes. -->

Stops us from grabbing latest python which seems to have ABI break in python 2.0

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


