### PR TITLE
Turn off ort ops for migx

### DIFF
--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -122,7 +122,7 @@ def run_onnxruntime(
         and ("DmlExecutionProvider" not in onnxruntime.get_available_providers())
     ):
         logger.error(
-            "Please install onnxruntime-gpu or onnxruntime-directml package instead of onnxruntime, and use a machine with GPU for testing gpu performance."
+            "Please install onnxruntime-gpu, onnxruntime-rocm or onnxruntime-directml package instead of onnxruntime, and use a machine with GPU for testing gpu performance."
         )
         return results
 
@@ -135,6 +135,16 @@ def run_onnxruntime(
                 "Please install onnxruntime-gpu-tensorrt package, and use a machine with GPU for testing gpu performance."
             )
             return results
+
+    if provider == "migraphx":
+        optimizer_info = OptimizerInfo.NOOPT
+        warm_up_repeat = 5
+        if "MIGraphXExecutionProvider" not in onnxruntime.get_available_providers():
+            logger.error(
+                "Please install onnxruntime-rocm package, and use a machine with GPU for testing gpu performance."
+            )
+            return results
+
 
     if optimizer_info == OptimizerInfo.NOOPT:
         logger.warning(

--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -145,7 +145,6 @@ def run_onnxruntime(
             )
             return results
 
-
     if optimizer_info == OptimizerInfo.NOOPT:
         logger.warning(
             f"OptimizerInfo is set to {optimizer_info}, graph optimizations specified in FusionOptions are not applied."

--- a/onnxruntime/python/tools/transformers/models/gpt2/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/models/gpt2/convert_to_onnx.py
@@ -375,7 +375,7 @@ def main(argv=None, experiment_name: str = "", run_id: str = "0", csv_filename: 
         provider = "MIGraphXExecutionProvider"
 
     session = create_onnxruntime_session(
-        output_path, args.use_gpu, provider , enable_all_optimization=True, verbose=args.verbose
+        output_path, args.use_gpu, provider, enable_all_optimization=True, verbose=args.verbose
     )
     if args.model_class == "GPT2LMHeadModel" and session is not None:
         parity_result = gpt2helper.test_parity(

--- a/onnxruntime/python/tools/transformers/models/gpt2/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/models/gpt2/convert_to_onnx.py
@@ -370,8 +370,12 @@ def main(argv=None, experiment_name: str = "", run_id: str = "0", csv_filename: 
     logger.info(f"Output path: {output_path}")
     model_size_in_MB = int(get_onnx_model_size(output_path, args.use_external_data_format) / 1024 / 1024)  # noqa: N806
 
+    provider = args.provider
+    if args.provider == "migraphx":
+        provider = "MIGraphXExecutionProvider"
+
     session = create_onnxruntime_session(
-        output_path, args.use_gpu, args.provider, enable_all_optimization=True, verbose=args.verbose
+        output_path, args.use_gpu, provider , enable_all_optimization=True, verbose=args.verbose
     )
     if args.model_class == "GPT2LMHeadModel" and session is not None:
         parity_result = gpt2helper.test_parity(


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Force MIGraphX EP on and turn off optimizations that try to invoke rocblas


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Since we've split support away from using ROCBLAs it appears some of the Onnxruntime optimizations default to use ROCm EP and then try to get MIGraphX to run ROCBLAS kernels when we don't invoke/use BLAS anymore. Furthermore some of the scripts need to explicitly invoke MIGraphX otherwise they silently fallback to ROCm EP and again try to use BLAS

