### PR TITLE
Rocm6.3 turn off ort ops for migx

### DIFF
--- a/onnxruntime/python/tools/transformers/benchmark.py
+++ b/onnxruntime/python/tools/transformers/benchmark.py
@@ -136,6 +136,15 @@ def run_onnxruntime(
             )
             return results
 
+    if provider == "migraphx":
+        optimizer_info = OptimizerInfo.NOOPT
+        warm_up_repeat = 5
+        if "MIGraphXExecutionProvider" not in onnxruntime.get_available_providers():
+            logger.error(
+                "Please install onnxruntime-rocm package, and use a machine with GPU for testing gpu performance."
+            )
+            return results
+
     if optimizer_info == OptimizerInfo.NOOPT:
         logger.warning(
             f"OptimizerInfo is set to {optimizer_info}, graph optimizations specified in FusionOptions are not applied."

--- a/onnxruntime/python/tools/transformers/models/gpt2/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/models/gpt2/convert_to_onnx.py
@@ -375,7 +375,7 @@ def main(argv=None, experiment_name: str = "", run_id: str = "0", csv_filename: 
         provider = "MIGraphXExecutionProvider"
 
     session = create_onnxruntime_session(
-        output_path, args.use_gpu, provider , enable_all_optimization=True, verbose=args.verbose
+        output_path, args.use_gpu, provider, enable_all_optimization=True, verbose=args.verbose
     )
     if args.model_class == "GPT2LMHeadModel" and session is not None:
         parity_result = gpt2helper.test_parity(

--- a/onnxruntime/python/tools/transformers/models/gpt2/convert_to_onnx.py
+++ b/onnxruntime/python/tools/transformers/models/gpt2/convert_to_onnx.py
@@ -370,8 +370,12 @@ def main(argv=None, experiment_name: str = "", run_id: str = "0", csv_filename: 
     logger.info(f"Output path: {output_path}")
     model_size_in_MB = int(get_onnx_model_size(output_path, args.use_external_data_format) / 1024 / 1024)  # noqa: N806
 
+    provider = args.provider
+    if args.provider == "migraphx":
+        provider = "MIGraphXExecutionProvider"
+
     session = create_onnxruntime_session(
-        output_path, args.use_gpu, args.provider, enable_all_optimization=True, verbose=args.verbose
+        output_path, args.use_gpu, provider , enable_all_optimization=True, verbose=args.verbose
     )
     if args.model_class == "GPT2LMHeadModel" and session is not None:
         parity_result = gpt2helper.test_parity(


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

rocm6.3 port of https://github.com/ROCm/onnxruntime/pull/54

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Needed to handle changes to how MIGraphX and some scripts invoke rocBLAS for kernels
