### PR TITLE
Add softmaxcrossentropy op

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -907,6 +907,7 @@ GetUnsupportedNodeIndices(const GraphViewer& graph_viewer,
                                                     "Sinh",
                                                     "Slice",
                                                     "Softmax",
+                                                    "SoftmaxCrossEntropyLoss",
                                                     "Softplus",
                                                     "Softsign",
                                                     "SpaceToDepth",
@@ -1015,15 +1016,6 @@ MIGraphXExecutionProvider::GetCapability(const onnxruntime::GraphViewer& graph_v
     }
 
     if (unsupported_nodes.size() > 10) {
-      return result;
-    }
-
-    // migraphx cannot handle Loop, If, and SoftmaxCrossEntropyLoss for now,
-    // so if a model contain any of these operators, fall back to CPU
-    std::unordered_set<std::string> vec_ops = {"SoftmaxCrossEntropyLoss"};
-    if (std::any_of(unsupported_nodes.begin(), unsupported_nodes.end(), [&](auto i) {
-          return (vec_ops.count(graph_viewer.GetNode(i)->OpType()) > 0);
-        })) {
       return result;
     }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Adds support for the softmaxcrossentropyloss operator - Remove the check for op as not supported

Update MIGraphX EP check for supported ops by leveraging API call we use in `migraphx-driver onnx --list` to get a list of supported onnx parsers built into MIGraphX. Stops us from having to continually update the EP when a new operator is added
Now things should auto updated automatically.  

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Used for runs with LlamaV2 and above. Allows us to run this fully in GPU. 

~Wont merge until: https://github.com/ROCm/AMDMIGraphX/pull/3008  is merged into MIGraphX~

Should be fine to merge with latest change should it work. Will test end to end once other PR merged. 