### PR TITLE
matmul_nbits: Use GPU_WARP_SIZE_HOST for host side code

### DIFF
--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cu
@@ -288,9 +288,8 @@ bool TryMatMul4Bits(
   if (n % kColsPerThreadBlock != 0 || k % 8 != 0 || m > 1) {
     return false;
   }
-  const int kWarpSize = GPU_WARP_SIZE_HOST;
   dim3 blocks((n + kColsPerThreadBlock - 1) / kColsPerThreadBlock, m);
-  dim3 threads(kWarpSize, kColsPerThreadBlock);
+  dim3 threads(GPU_WARP_SIZE_HOST, kColsPerThreadBlock);
   int blocks_per_K = (k + block_size - 1) / block_size;
   int shared_mem_size = sizeof(T) * blocks_per_K * kColsPerThreadBlock +
                         (zero_points != nullptr ? (blocks_per_K + 1) / 2 * kColsPerThreadBlock * 2 : 0);

--- a/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cu
+++ b/onnxruntime/contrib_ops/cuda/quantization/matmul_nbits.cu
@@ -288,6 +288,7 @@ bool TryMatMul4Bits(
   if (n % kColsPerThreadBlock != 0 || k % 8 != 0 || m > 1) {
     return false;
   }
+  const int kWarpSize = GPU_WARP_SIZE_HOST;
   dim3 blocks((n + kColsPerThreadBlock - 1) / kColsPerThreadBlock, m);
   dim3 threads(kWarpSize, kColsPerThreadBlock);
   int blocks_per_K = (k + block_size - 1) / block_size;


### PR DESCRIPTION
For ROCm device, the host side code needs to call GPU_WARP_SIZE_HOST to query warpsize of the underlying GPU device.

Fixes MatMulNBits tests on Navi.

