### PR TITLE
[Do not Merge] Upgrade CK commithash to fix compilation errors with Clang20.0

### DIFF
--- a/cgmanifests/generated/cgmanifest.json
+++ b/cgmanifests/generated/cgmanifest.json
@@ -336,7 +336,7 @@
       "component": {
         "type": "git",
         "git": {
-          "commitHash": "204da9c522cebec5220bba52cd3542ebcaf99e7a",
+          "commitHash": "42e6dceaccda48ec99eff93e181df49abef69c11",
           "repositoryUrl": "https://github.com/ROCmSoftwarePlatform/composable_kernel.git"
         },
         "comments": "composable_kernel"

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -56,5 +56,5 @@ tensorboard;https://github.com/tensorflow/tensorboard/archive/373eb09e4c5d2b3cc2
 cutlass;https://github.com/NVIDIA/cutlass/archive/refs/tags/v3.5.0.zip;ae038931b9fc2c416c17d9cda91d9706b343f56d
 utf8_range;https://github.com/protocolbuffers/utf8_range/archive/72c943dea2b9240cd09efde15191e144bc7c7d38.zip;9925739c9debc0efa2adcb194d371a35b6a03156
 extensions;https://github.com/microsoft/onnxruntime-extensions/archive/94142d8391c9791ec71c38336436319a2d4ac7a0.zip;4365ac5140338b4cb75a39944a4be276e3829b3c
-composable_kernel;https://github.com/ROCmSoftwarePlatform/composable_kernel/archive/204da9c522cebec5220bba52cd3542ebcaf99e7a.zip;1827348efd47831c13074245274d41b7cae8a557
+composable_kernel;https://github.com/ROCmSoftwarePlatform/composable_kernel/archive/42e6dceaccda48ec99eff93e181df49abef69c11.zip;c1632bacf090d8802547fe161f867222c627796c
 directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.613.1.zip;47653509a3371eabb156360f42faf582f314bf2e


### PR DESCRIPTION
Updated CK commit hash to https://github.com/ROCm/composable_kernel/commit/42e6dceaccda48ec99eff93e181df49abef69c11