### PR TITLE
[ROCm EP] Fix transpose helpler via removing default trivial constructor

### DIFF
--- a/onnxruntime/core/providers/rocm/shared_inc/fpgeneric.h
+++ b/onnxruntime/core/providers/rocm/shared_inc/fpgeneric.h
@@ -501,7 +501,6 @@ inline hipblasStatus_t hipblasTransposeHelper(hipStream_t /*stream*/, hipblasHan
   return hipblasDgeam(handle, transa, transb, m, n, alpha, A, lda, beta, B, ldb, C, ldc);
 }
 
-inline bool CanUse_hipblasTransposeHelper_MLFloat16(int /*m*/, int /*n*/) { return true; }  // CUDA has a limited grid size of 65536, ROCm has higher limits.
 hipblasStatus_t hipblasTransposeHelper(hipStream_t stream, hipblasHandle_t, hipblasOperation_t, hipblasOperation_t, int m, int n, const half*, const half* A, int, const half*, const half*, int, half* C, int);
 
 // copy


### PR DESCRIPTION

### Description
<!-- Describe your changes. -->
Remove inline default transposeHelper and ensure we use the proper cjeck via CanUse_hipBlasTransposeHelper_MLFloat16



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Required as some gfx targets require gridsize for transpse be under the 65535 limit otherwise we'll error out.

Lipamdhip.so will error out in newer ROCm to warn about this but in previous cases we would get undefined behavior if gridsize was larger than anticipated.
