### PR TITLE
Rename `HIPPinnedAllocator` to `MIGraphXPinnedAllocator`

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_allocator.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_allocator.cc
@@ -68,7 +68,7 @@ void* MIGraphXExternalAllocator::Reserve(size_t size) {
   return p;
 }
 
-void* HIPPinnedAllocator::Alloc(size_t size) {
+void* MIGraphXPinnedAllocator::Alloc(size_t size) {
   void* p = nullptr;
   if (size > 0) {
     HIP_CALL_THROW(hipHostMalloc((void**)&p, size));
@@ -76,7 +76,7 @@ void* HIPPinnedAllocator::Alloc(size_t size) {
   return p;
 }
 
-void HIPPinnedAllocator::Free(void* p) {
+void MIGraphXPinnedAllocator::Free(void* p) {
   HIP_CALL_THROW(hipHostFree(p));
 }
 

--- a/onnxruntime/core/providers/migraphx/migraphx_allocator.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_allocator.h
@@ -49,17 +49,16 @@ class MIGraphXExternalAllocator : public MIGraphXAllocator {
   std::unordered_set<void*> reserved_;
 };
 
-// TODO: add a default constructor
-class HIPPinnedAllocator : public IAllocator {
+class MIGraphXPinnedAllocator final : public IAllocator {
  public:
-  HIPPinnedAllocator(int device_id, const char* name)
+  MIGraphXPinnedAllocator(const int device_id, const char* name)
       : IAllocator(
-            OrtMemoryInfo(name, OrtAllocatorType::OrtDeviceAllocator,
+            OrtMemoryInfo(name, OrtDeviceAllocator,
                           OrtDevice(OrtDevice::CPU, OrtDevice::MemType::HIP_PINNED, static_cast<OrtDevice::DeviceId>(device_id)),
                           device_id, OrtMemTypeCPUOutput)) {}
 
-  virtual void* Alloc(size_t size) override;
-  virtual void Free(void* p) override;
+  void* Alloc(size_t size) override;
+  void Free(void* p) override;
 };
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -334,7 +334,7 @@ std::vector<AllocatorPtr> MIGraphXExecutionProvider::CreatePreferredAllocators()
       [](OrtDevice::DeviceId device_id) { return std::make_unique<MIGraphXAllocator>(device_id, onnxruntime::CUDA); }, info_.device_id);
   AllocatorCreationInfo pinned_allocator_info(
       [](OrtDevice::DeviceId device_id) {
-        return std::make_unique<HIPPinnedAllocator>(device_id, onnxruntime::CUDA_PINNED);
+        return std::make_unique<MIGraphXPinnedAllocator>(device_id, onnxruntime::CUDA_PINNED);
       },
       0);
   return std::vector<AllocatorPtr>{CreateAllocator(default_memory_info), CreateAllocator(pinned_allocator_info)};

--- a/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
@@ -40,7 +40,7 @@ struct ProviderInfo_MIGraphX_Impl final : ProviderInfo_MIGraphX {
   }
 
   std::unique_ptr<IAllocator> CreateMIGraphXPinnedAllocator(int16_t device_id, const char* name) override {
-    return std::make_unique<HIPPinnedAllocator>(device_id, name);
+    return std::make_unique<MIGraphXPinnedAllocator>(device_id, name);
   }
 
   void MIGraphXMemcpy_HostToDevice(void* dst, const void* src, size_t count) override {


### PR DESCRIPTION
### Description
Rename class name from `HIPPinnedAllocator` to `MIGraphXPinnedAllocator`.

### Motivation and Context
To preserve a consistent naming convention.

