### PR TITLE
ROCm: Ignore deprecated warning for compress_impl

### DIFF
--- a/onnxruntime/core/providers/cuda/tensor/compress_impl.cu
+++ b/onnxruntime/core/providers/cuda/tensor/compress_impl.cu
@@ -16,6 +16,9 @@
 #include <thrust/functional.h>
 #include <thrust/iterator/transform_iterator.h>
 
+#ifdef USE_ROCM
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 namespace onnxruntime {
 namespace cuda {
 


### PR DESCRIPTION
Error signature: 4 warnings generated when compiling for gfx1100.
/onnxruntime/build/Linux/Release/amdgpu/onnxruntime/core/providers/rocm/tensor/compress_impl.cu:27:37: error: 'unary_function<signed char, int>' is deprecated [-Werror,-Wdeprecated-declarations]
 | struct CastToInt32 : public thrust::unary_function<int8_t, int32_t> {



