### PR TITLE
Fix pybind input for calibration table loading

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
@@ -192,7 +192,7 @@ inline bool ReadDynamicRange(const std::string file_name,
                              std::unordered_map<std::string,
                                                 float>& dynamic_range_map) {
   std::ifstream infile(file_name, std::ios::binary | std::ios::in);
-  if (!infile) {
+  if (!infile.good()) {
     return false;
   }
 

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -845,7 +845,7 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
 #endif
   } else if (type == kMIGraphXExecutionProvider) {
 #ifdef USE_MIGRAPHX
-    std::string model_cache_path;
+    std::string model_cache_path, cal_table_name;
     auto it = provider_options_map.find(type);
     if (it != provider_options_map.end()) {
       OrtMIGraphXProviderOptions params{
@@ -898,7 +898,8 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
           }
         } else if (option.first == migraphx_provider_option::kInt8CalibTable) {
           if (!option.second.empty()) {
-            params.migraphx_int8_calibration_table_name = option.second.c_str();
+            cal_table_name = option.second;
+            params.migraphx_int8_calibration_table_name = cal_table_name.c_str();
           } else {
             ORT_THROW(
                 "[ERROR] [MIGraphX] The value for the key 'migraphx_int8_calibration_table_name' should be a "


### PR DESCRIPTION
This fixes an issue we were seeing with calibration able using a spare reference for input. Caused us to try to use a stale reference which intermttently referenced a non existent or incorrect input causing calibration to fail or undefined behavior due to trying to use a reference address as a c_str() directly.

Added a check using the .good() call for the ifstream when reading calibration tables as well to ensure we're not only getting a valid no null stream but no other errors are present on open

### Description
<!-- Describe your changes. -->
Simple change to ensure we don't copy a reference on the stack which goes stale, but create a new string that triggers an explicit copy from ref->string before we convert things to c_str()


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

This fixes a reference bug found when we attempt to use this value and other string based inputs are used via the pybind interface. We get undefined behavior and intermittent failures. This is a critical bugfix.

