### PR TITLE
Promote fixes from 6.4 to 6.5 branches and testing

### DIFF
--- a/cmake/external/composable_kernel.cmake
+++ b/cmake/external/composable_kernel.cmake
@@ -2,6 +2,8 @@ set(PATCH_CLANG ${PROJECT_SOURCE_DIR}/patches/composable_kernel/Fix_Clang_Build.
 set(PATCH_GFX12X ${PROJECT_SOURCE_DIR}/patches/composable_kernel/Add_gfx12x_support.patch)
 set(PATCH_GFX950 ${PROJECT_SOURCE_DIR}/patches/composable_kernel/Add_gfx950.patch)
 set(PATCH_GFX950_TILE ${PROJECT_SOURCE_DIR}/patches/composable_kernel/Add_gfx950_tile.patch)
+set(PATCH_Clang20 ${PROJECT_SOURCE_DIR}/patches/composable_kernel/Fix_Clang20_error.patch)
+set(PATCH_Clang20_GFX12 ${PROJECT_SOURCE_DIR}/patches/composable_kernel/Fix_Clang20_gfx12.patch)
 
 include(FetchContent)
 onnxruntime_fetchcontent_declare(composable_kernel
@@ -10,7 +12,9 @@ onnxruntime_fetchcontent_declare(composable_kernel
   PATCH_COMMAND ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PATCH_CLANG} &&
                 ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PATCH_GFX12X} &&
                 ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PATCH_GFX950} &&
-                ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PATCH_GFX950_TILE}
+                ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PATCH_GFX950_TILE} &&
+                ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PATCH_Clang20} &&
+                ${Patch_EXECUTABLE} --binary --ignore-whitespace -p1 < ${PATCH_Clang20_GFX12}
 )
 
 FetchContent_GetProperties(composable_kernel)

--- a/cmake/patches/composable_kernel/Fix_Clang20_error.patch
+++ b/cmake/patches/composable_kernel/Fix_Clang20_error.patch
@@ -1,0 +1,358 @@
+diff --git a/include/ck/tensor_operation/gpu/block/blockwise_gemm_pipeline_xdlops.hpp b/include/ck/tensor_operation/gpu/block/blockwise_gemm_pipeline_xdlops.hpp
+index 5d137e67..758f25a5 100644
+--- a/include/ck/tensor_operation/gpu/block/blockwise_gemm_pipeline_xdlops.hpp
++++ b/include/ck/tensor_operation/gpu/block/blockwise_gemm_pipeline_xdlops.hpp
+@@ -406,7 +406,7 @@ struct BlockwiseGemmXdlops_pipeline_v4
+     }
+
+     template <>
+-    __device__ static constexpr auto TailScheduler<1>()
++    __device__ constexpr auto TailScheduler<1>()
+     {
+         // schedule
+         constexpr auto num_ds_read_inst =
+@@ -433,7 +433,7 @@ struct BlockwiseGemmXdlops_pipeline_v4
+     }
+
+     template <>
+-    __device__ static constexpr auto TailScheduler<2>()
++    __device__ constexpr auto TailScheduler<2>()
+     {
+         // schedule
+         constexpr auto num_ds_read_inst =
+diff --git a/include/ck/tensor_operation/gpu/warp/dpp_gemm.hpp b/include/ck/tensor_operation/gpu/warp/dpp_gemm.hpp
+index a1844316..409bb9f6 100644
+--- a/include/ck/tensor_operation/gpu/warp/dpp_gemm.hpp
++++ b/include/ck/tensor_operation/gpu/warp/dpp_gemm.hpp
+@@ -324,55 +324,55 @@ struct DppSelector
+     static constexpr auto GetDpp();
+
+     template <>
+-    static constexpr auto GetDpp<half_t, 8, 32>()
++    constexpr auto GetDpp<half_t, 8, 32>()
+     {
+         return DppInstr::dpp8_f16_8x32x2;
+     }
+
+     template <>
+-    static constexpr auto GetDpp<half_t, 8, 16>()
++    constexpr auto GetDpp<half_t, 8, 16>()
+     {
+         return DppInstr::dpp8_f16_8x16x2;
+     }
+
+     template <>
+-    static constexpr auto GetDpp<half_t, 16, 16>()
++    constexpr auto GetDpp<half_t, 16, 16>()
+     {
+         return DppInstr::dpp8_f16_16x16x2;
+     }
+
+     template <>
+-    static constexpr auto GetDpp<half_t, 32, 8>()
++    constexpr auto GetDpp<half_t, 32, 8>()
+     {
+         return DppInstr::dpp8_f16_32x8x2;
+     }
+
+     template <>
+-    static constexpr auto GetDpp<half_t, 1, 32>()
++    constexpr auto GetDpp<half_t, 1, 32>()
+     {
+         return DppInstr::dpp8_f16_1x32x2;
+     }
+
+     template <>
+-    static constexpr auto GetDpp<half_t, 2, 32>()
++    constexpr auto GetDpp<half_t, 2, 32>()
+     {
+         return DppInstr::dpp8_f16_2x32x2;
+     }
+
+     template <>
+-    static constexpr auto GetDpp<half_t, 2, 16>()
++    constexpr auto GetDpp<half_t, 2, 16>()
+     {
+         return DppInstr::dpp8_f16_2x16x2;
+     }
+
+     template <>
+-    static constexpr auto GetDpp<half_t, 4, 16>()
++    constexpr auto GetDpp<half_t, 4, 16>()
+     {
+         return DppInstr::dpp8_f16_4x16x2;
+     }
+
+     template <>
+-    static constexpr auto GetDpp<half_t, 4, 32>()
++    constexpr auto GetDpp<half_t, 4, 32>()
+     {
+         return DppInstr::dpp8_f16_4x32x2;
+     }
+diff --git a/include/ck/tensor_operation/gpu/warp/wmma_gemm.hpp b/include/ck/tensor_operation/gpu/warp/wmma_gemm.hpp
+index 9a9ebf55..b435a2a1 100644
+--- a/include/ck/tensor_operation/gpu/warp/wmma_gemm.hpp
++++ b/include/ck/tensor_operation/gpu/warp/wmma_gemm.hpp
+@@ -415,7 +415,7 @@ struct WmmaSelector
+     static constexpr auto GetWmma();
+
+     template <>
+-    static constexpr auto GetWmma<half_t, half_t, float, 16, 16>()
++    constexpr auto GetWmma<half_t, half_t, float, 16, 16>()
+     {
+ #ifdef __gfx12__
+         return WmmaInstr::wmma_f32_16x16x16_f16_gfx12;
+@@ -425,7 +425,7 @@ struct WmmaSelector
+     }
+
+     template <>
+-    static constexpr auto GetWmma<bhalf_t, bhalf_t, float, 16, 16>()
++    constexpr auto GetWmma<bhalf_t, bhalf_t, float, 16, 16>()
+     {
+ #ifdef __gfx12__
+         return WmmaInstr::wmma_f32_16x16x16_bf16_gfx12;
+@@ -435,19 +435,19 @@ struct WmmaSelector
+     }
+
+     template <>
+-    static constexpr auto GetWmma<half_t, half_t, half_t, 16, 16>()
++    constexpr auto GetWmma<half_t, half_t, half_t, 16, 16>()
+     {
+         return WmmaInstr::wmma_f16_16x16x16_f16;
+     }
+
+     template <>
+-    static constexpr auto GetWmma<bhalf_t, bhalf_t, bhalf_t, 16, 16>()
++    constexpr auto GetWmma<bhalf_t, bhalf_t, bhalf_t, 16, 16>()
+     {
+         return WmmaInstr::wmma_bf16_16x16x16_bf16;
+     }
+
+     template <>
+-    static constexpr auto GetWmma<int8_t, int8_t, int, 16, 16>()
++    constexpr auto GetWmma<int8_t, int8_t, int, 16, 16>()
+     {
+ #ifdef __gfx12__
+         return WmmaInstr::wmma_i32_16x16x16_iu8_gfx12;
+@@ -458,7 +458,7 @@ struct WmmaSelector
+
+ #ifdef CK_EXPERIMENTAL_BIT_INT_EXTENSION_INT4
+     template <>
+-    static constexpr auto GetWmma<int4_t, int4_t, int, 16, 16>()
++    constexpr auto GetWmma<int4_t, int4_t, int, 16, 16>()
+     {
+         return WmmaInstr::wmma_i32_16x16x16_iu4;
+     }
+diff --git a/include/ck/tensor_operation/gpu/warp/xdlops_gemm.hpp b/include/ck/tensor_operation/gpu/warp/xdlops_gemm.hpp
+index 835075b7..24fac91e 100644
+--- a/include/ck/tensor_operation/gpu/warp/xdlops_gemm.hpp
++++ b/include/ck/tensor_operation/gpu/warp/xdlops_gemm.hpp
+@@ -651,97 +651,97 @@ struct MfmaSelector
+     static constexpr auto GetMfma();
+
+     template <>
+-    static constexpr auto GetMfma<double, 16, 16>()
++    constexpr auto GetMfma<double, 16, 16>()
+     {
+         return MfmaInstr::mfma_f64_16x16x4f64;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<float, 64, 64>()
++    constexpr auto GetMfma<float, 64, 64>()
+     {
+         return MfmaInstr::mfma_f32_32x32x1xf32;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<float, 32, 64>()
++    constexpr auto GetMfma<float, 32, 64>()
+     {
+         return MfmaInstr::mfma_f32_32x32x1xf32;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<float, 16, 64>()
++    constexpr auto GetMfma<float, 16, 64>()
+     {
+         return MfmaInstr::mfma_f32_16x16x1xf32;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<float, 8, 64>()
++    constexpr auto GetMfma<float, 8, 64>()
+     {
+         return MfmaInstr::mfma_f32_4x4x1xf32;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<float, 4, 64>()
++    constexpr auto GetMfma<float, 4, 64>()
+     {
+         return MfmaInstr::mfma_f32_4x4x1xf32;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<float, 32, 32>()
++    constexpr auto GetMfma<float, 32, 32>()
+     {
+         return MfmaInstr::mfma_f32_32x32x2xf32;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<float, 16, 16>()
++    constexpr auto GetMfma<float, 16, 16>()
+     {
+         return MfmaInstr::mfma_f32_16x16x4xf32;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<half_t, 64, 64>()
++    constexpr auto GetMfma<half_t, 64, 64>()
+     {
+         return MfmaInstr::mfma_f32_32x32x4f16;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<half_t, 32, 64>()
++    constexpr auto GetMfma<half_t, 32, 64>()
+     {
+         return MfmaInstr::mfma_f32_32x32x4f16;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<half_t, 32, 32>()
++    constexpr auto GetMfma<half_t, 32, 32>()
+     {
+         return MfmaInstr::mfma_f32_32x32x8f16;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<half_t, 16, 16>()
++    constexpr auto GetMfma<half_t, 16, 16>()
+     {
+         return MfmaInstr::mfma_f32_16x16x16f16;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<half_t, 16, 64>()
++    constexpr auto GetMfma<half_t, 16, 64>()
+     {
+         return MfmaInstr::mfma_f32_16x16x4f16;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<half_t, 8, 64>()
++    constexpr auto GetMfma<half_t, 8, 64>()
+     {
+         return MfmaInstr::mfma_f32_4x4x4f16;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<half_t, 4, 64>()
++    constexpr auto GetMfma<half_t, 4, 64>()
+     {
+         return MfmaInstr::mfma_f32_4x4x4f16;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<bhalf_t, 32, 32>()
++    constexpr auto GetMfma<bhalf_t, 32, 32>()
+     {
+ #if defined(CK_USE_AMD_MFMA_BF16_1K_OP)
+         return MfmaInstr::mfma_f32_32x32x8bf16_1k;
+@@ -751,7 +751,7 @@ struct MfmaSelector
+     }
+
+     template <>
+-    static constexpr auto GetMfma<bhalf_t, 16, 16>()
++    constexpr auto GetMfma<bhalf_t, 16, 16>()
+     {
+ #if defined(CK_USE_AMD_MFMA_BF16_1K_OP)
+         return MfmaInstr::mfma_f32_16x16x16bf16_1k;
+@@ -762,72 +762,72 @@ struct MfmaSelector
+
+ #if defined(CK_USE_AMD_MFMA_GFX940)
+     template <>
+-    static constexpr auto GetMfma<int8_t, 32, 32>()
++    constexpr auto GetMfma<int8_t, 32, 32>()
+     {
+         return MfmaInstr::mfma_i32_32x32x16i8;
+     }
+     template <>
+-    static constexpr auto GetMfma<int8_t, 16, 16>()
++    constexpr auto GetMfma<int8_t, 16, 16>()
+     {
+         return MfmaInstr::mfma_i32_16x16x32i8;
+     }
+ #else
+     template <>
+-    static constexpr auto GetMfma<int8_t, 32, 32>()
++    constexpr auto GetMfma<int8_t, 32, 32>()
+     {
+         return MfmaInstr::mfma_i32_32x32x8i8;
+     }
+     template <>
+-    static constexpr auto GetMfma<int8_t, 16, 16>()
++    constexpr auto GetMfma<int8_t, 16, 16>()
+     {
+         return MfmaInstr::mfma_i32_16x16x16i8;
+     }
+ #endif
+
+     template <>
+-    static constexpr auto GetMfma<f8_t, 32, 32>()
++    constexpr auto GetMfma<f8_t, 32, 32>()
+     {
+         return MfmaInstr::mfma_f32_32x32x16f8f8;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<f8_t, 16, 16>()
++    constexpr auto GetMfma<f8_t, 16, 16>()
+     {
+         return MfmaInstr::mfma_f32_16x16x32f8f8;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<bf8_t, 32, 32>()
++    constexpr auto GetMfma<bf8_t, 32, 32>()
+     {
+         return MfmaInstr::mfma_f32_32x32x16bf8bf8;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<bf8_t, 16, 16>()
++    constexpr auto GetMfma<bf8_t, 16, 16>()
+     {
+         return MfmaInstr::mfma_f32_16x16x32bf8bf8;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<f8_t, 32, 32, bf8_t>()
++    constexpr auto GetMfma<f8_t, 32, 32, bf8_t>()
+     {
+         return MfmaInstr::mfma_f32_32x32x16f8bf8;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<f8_t, 16, 16, bf8_t>()
++    constexpr auto GetMfma<f8_t, 16, 16, bf8_t>()
+     {
+         return MfmaInstr::mfma_f32_16x16x32f8bf8;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<bf8_t, 32, 32, f8_t>()
++    constexpr auto GetMfma<bf8_t, 32, 32, f8_t>()
+     {
+         return MfmaInstr::mfma_f32_32x32x16bf8f8;
+     }
+
+     template <>
+-    static constexpr auto GetMfma<bf8_t, 16, 16, f8_t>()
++    constexpr auto GetMfma<bf8_t, 16, 16, f8_t>()
+     {
+         return MfmaInstr::mfma_f32_16x16x32bf8f8;
+     }
+

--- a/cmake/patches/composable_kernel/Fix_Clang20_gfx12.patch
+++ b/cmake/patches/composable_kernel/Fix_Clang20_gfx12.patch
@@ -1,0 +1,152 @@
+diff --git a/include/ck/tensor_operation/gpu/block/blockwise_gemm_dpp.hpp b/include/ck/tensor_operation/gpu/block/blockwise_gemm_dpp.hpp
+index d62ed4b15..f469b83b9 100644
+--- a/include/ck/tensor_operation/gpu/block/blockwise_gemm_dpp.hpp
++++ b/include/ck/tensor_operation/gpu/block/blockwise_gemm_dpp.hpp
+@@ -300,7 +300,7 @@ struct BlockwiseGemmDpp_ak0mak1_bk0nbk1_m0n0m1n1m2n2
+                     constexpr index_t c_offset =
+                         c_thread_desc_.CalculateOffset(make_tuple(m0, n0, 0));
+
+-                    dpp_gemm.template Run(a_thread_vec.template AsType<dpp_input_type>(),
++                    dpp_gemm.template Run<>(a_thread_vec.template AsType<dpp_input_type>(),
+                                           b_thread_vec.template AsType<dpp_input_type>(),
+                                           c_thread_buf.GetVectorTypeReference(Number<c_offset>{}));
+                 });
+diff --git a/include/ck/tensor_operation/gpu/block/blockwise_gemm_pipeline_xdlops.hpp b/include/ck/tensor_operation/gpu/block/blockwise_gemm_pipeline_xdlops.hpp
+index 758f25a5b..aa0c42b91 100644
+--- a/include/ck/tensor_operation/gpu/block/blockwise_gemm_pipeline_xdlops.hpp
++++ b/include/ck/tensor_operation/gpu/block/blockwise_gemm_pipeline_xdlops.hpp
+@@ -613,7 +613,7 @@ struct BlockwiseGemmXdlops_pipeline_v4
+                             constexpr index_t c_offset =
+                                 c_thread_desc_.CalculateOffset(make_tuple(m0, n0, 0));
+
+-                            xdlops_gemm.template Run(
++                            xdlops_gemm.template Run<>(
+                                 a_thread_vec.template AsType<mfma_input_type>(),
+                                 b_thread_vec.template AsType<mfma_input_type>(),
+                                 c_thread_buf.GetVectorTypeReference(Number<c_offset>{}));
+@@ -681,7 +681,7 @@ struct BlockwiseGemmXdlops_pipeline_v4
+                             constexpr index_t c_offset =
+                                 c_thread_desc_.CalculateOffset(make_tuple(m0, n0, 0));
+
+-                            xdlops_gemm.template Run(
++                            xdlops_gemm.template Run<>(
+                                 a_thread_vec.template AsType<mfma_input_type>(),
+                                 b_thread_vec.template AsType<mfma_input_type>(),
+                                 c_thread_buf.GetVectorTypeReference(Number<c_offset>{}));
+@@ -749,7 +749,7 @@ struct BlockwiseGemmXdlops_pipeline_v4
+                         constexpr index_t c_offset =
+                             c_thread_desc_.CalculateOffset(make_tuple(m0, n0, 0));
+
+-                        xdlops_gemm.template Run(
++                        xdlops_gemm.template Run<>(
+                             a_thread_vec.template AsType<mfma_input_type>(),
+                             b_thread_vec.template AsType<mfma_input_type>(),
+                             c_thread_buf.GetVectorTypeReference(Number<c_offset>{}));
+@@ -808,7 +808,7 @@ struct BlockwiseGemmXdlops_pipeline_v4
+                         constexpr index_t c_offset =
+                             c_thread_desc_.CalculateOffset(make_tuple(m0, n0, 0));
+
+-                        xdlops_gemm.template Run(
++                        xdlops_gemm.template Run<>(
+                             a_thread_vec.template AsType<mfma_input_type>(),
+                             b_thread_vec.template AsType<mfma_input_type>(),
+                             c_thread_buf.GetVectorTypeReference(Number<c_offset>{}));
+@@ -840,7 +840,7 @@ struct BlockwiseGemmXdlops_pipeline_v4
+                         constexpr index_t c_offset =
+                             c_thread_desc_.CalculateOffset(make_tuple(m0, n0, 0));
+
+-                        xdlops_gemm.template Run(
++                        xdlops_gemm.template Run<>(
+                             a_thread_vec.template AsType<mfma_input_type>(),
+                             b_thread_vec.template AsType<mfma_input_type>(),
+                             c_thread_buf.GetVectorTypeReference(Number<c_offset>{}));
+@@ -901,7 +901,7 @@ struct BlockwiseGemmXdlops_pipeline_v4
+                         constexpr index_t c_offset =
+                             c_thread_desc_.CalculateOffset(make_tuple(m0, n0, 0));
+
+-                        xdlops_gemm.template Run(
++                        xdlops_gemm.template Run<>(
+                             a_thread_vec.template AsType<mfma_input_type>(),
+                             b_thread_vec.template AsType<mfma_input_type>(),
+                             c_thread_buf.GetVectorTypeReference(Number<c_offset>{}));
+@@ -939,7 +939,7 @@ struct BlockwiseGemmXdlops_pipeline_v4
+                         constexpr index_t c_offset =
+                             c_thread_desc_.CalculateOffset(make_tuple(m0, n0, 0));
+
+-                        xdlops_gemm.template Run(
++                        xdlops_gemm.template Run<>(
+                             a_thread_vec.template AsType<mfma_input_type>(),
+                             b_thread_vec.template AsType<mfma_input_type>(),
+                             c_thread_buf.GetVectorTypeReference(Number<c_offset>{}));
+diff --git a/include/ck/tensor_operation/gpu/block/blockwise_gemm_wmma.hpp b/include/ck/tensor_operation/gpu/block/blockwise_gemm_wmma.hpp
+index 7eb7d42eb..59b0460be 100644
+--- a/include/ck/tensor_operation/gpu/block/blockwise_gemm_wmma.hpp
++++ b/include/ck/tensor_operation/gpu/block/blockwise_gemm_wmma.hpp
+@@ -352,7 +352,7 @@ struct BlockwiseGemmWMMA
+                             constexpr index_t c_offset =
+                                 c_thread_desc_.CalculateOffset(make_tuple(m0, n0, 0));
+
+-                            wmma_gemm.template Run(
++                            wmma_gemm.template Run<>(
+                                 a_thread_vec.template AsType<wmma_input_type_a>(),
+                                 b_thread_vec.template AsType<wmma_input_type_b>(),
+                                 c_thread_buf.GetVectorTypeReference(Number<c_offset>{}));
+@@ -406,7 +406,7 @@ struct BlockwiseGemmWMMA
+                         constexpr index_t c_offset =
+                             c_thread_desc_.CalculateOffset(make_tuple(m0, n0, 0));
+
+-                        wmma_gemm.template Run(
++                        wmma_gemm.template Run<>(
+                             a_thread_vec.template AsType<wmma_input_type_a>(),
+                             b_thread_vec.template AsType<wmma_input_type_b>(),
+                             c_thread_buf.GetVectorTypeReference(Number<c_offset>{}));
+@@ -850,7 +850,7 @@ struct BlockwiseGemmWMMA
+                             constexpr index_t c_offset =
+                                 c_thread_desc_.CalculateOffset(make_tuple(m0, n0, 0));
+
+-                            wmma_gemm.template Run(
++                            wmma_gemm.template Run<>(
+                                 a_thread_vec.template AsType<wmma_input_type_a>(),
+                                 b_thread_vec.template AsType<wmma_input_type_b>(),
+                                 c_thread_buf.GetVectorTypeReference(Number<c_offset>{}));
+@@ -909,7 +909,7 @@ struct BlockwiseGemmWMMA
+                         constexpr index_t c_offset =
+                             c_thread_desc_.CalculateOffset(make_tuple(m0, n0, 0));
+
+-                        wmma_gemm.template Run(
++                        wmma_gemm.template Run<>(
+                             a_thread_vec.template AsType<wmma_input_type_a>(),
+                             b_thread_vec.template AsType<wmma_input_type_b>(),
+                             c_thread_buf.GetVectorTypeReference(Number<c_offset>{}));
+diff --git a/include/ck/tensor_operation/gpu/block/blockwise_gemm_xdlops.hpp b/include/ck/tensor_operation/gpu/block/blockwise_gemm_xdlops.hpp
+index 1f7d50429..ae5f84762 100644
+--- a/include/ck/tensor_operation/gpu/block/blockwise_gemm_xdlops.hpp
++++ b/include/ck/tensor_operation/gpu/block/blockwise_gemm_xdlops.hpp
+@@ -340,7 +340,7 @@ struct BlockwiseGemmXdlops_k0mk1_k0nk1_m0n0m1n1m2m3m4n2_v1
+                     constexpr index_t c_offset =
+                         c_thread_desc_.CalculateOffset(make_tuple(m0, n0, 0));
+
+-                    xdlops_gemm.template Run(
++                    xdlops_gemm.template Run<>(
+                         a_thread_vec.template AsType<mfma_input_type_a>(),
+                         b_thread_vec.template AsType<mfma_input_type_b>(),
+                         c_thread_buf.GetVectorTypeReference(Number<c_offset>{}));
+@@ -537,7 +537,7 @@ struct BlockwiseGemmXdlopsInterwave_k0mk1_k0nk1_m0n0m1n1m2m3m4n2_v1
+
+                         // TODO: insert setprio in more precise manner since we
+                         // could have more than >1 MFMA instructions in single call
+-                        xdlops_gemm.template Run(
++                        xdlops_gemm.template Run<>(
+                             a_thread_vec.template AsType<mfma_input_type_a>(),
+                             b_thread_vec.template AsType<mfma_input_type_b>(),
+                             c_thread_buf.GetVectorTypeReference(Number<c_offset>{}));
+@@ -970,7 +970,7 @@ struct BlockwiseGemmXdlops_v2
+                     constexpr index_t c_offset =
+                         c_thread_desc_.CalculateOffset(make_tuple(m0, n0, 0));
+
+-                    xdlops_gemm.template Run(
++                    xdlops_gemm.template Run<>(
+                         a_thread_vec.template AsType<mfma_input_type>(),
+                         b_thread_vec.template AsType<mfma_input_type>(),
+                         c_thread_buf.GetVectorTypeReference(Number<c_offset>{}));
+

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -623,10 +623,7 @@ typedef struct OrtMIGraphXProviderOptions {
   int migraphx_int8_enable;                          // MIGraphX INT8 precision. Default 0 = false, nonzero = true
   int migraphx_use_native_calibration_table;         // MIGraphx INT8 cal table. Default 0 = false, noznero = true
   const char* migraphx_int8_calibration_table_name;  // MIGraphx INT8 calibration table name
-  int migraphx_save_compiled_model;                  // migraphx save compiled model. Default 0 = false, noznero = true
-  const char* migraphx_save_model_path;              // migraphx model path name
-  int migraphx_load_compiled_model;                  // migraphx int8 cal table. Default 0 = false, noznero = true
-  const char* migraphx_load_model_path;              // migraphx model path name
+  const char* migraphx_cache_dir;                    // MIGraphX model cache directory
   bool migraphx_exhaustive_tune;                     // migraphx tuned compile  Default = false
 
   /** \brief MIGraphX memory limit (To use all possible memory pass in maximum size_t)

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -119,6 +119,7 @@ MIGraphXExecutionProvider::~MIGraphXExecutionProvider() {
 void MIGraphXExecutionProvider::get_flags_from_session_info(const MIGraphXExecutionProviderInfo& info) {
   // Set GPU device to be used
   HIP_CALL_THROW(hipSetDevice(info_.device_id));
+  HIP_CALL_THROW(hipGetDeviceProperties(&device_prop_, info.device_id));
   t_ = migraphx::target(info.target_device.c_str());
 
   // Quantization
@@ -155,10 +156,7 @@ void MIGraphXExecutionProvider::get_flags_from_session_info(const MIGraphXExecut
   }
 
   // Save/load migraphx compiled models
-  save_compiled_model_ = info.save_compiled_model;
-  save_compiled_path_ = info.save_model_file;
-  load_compiled_model_ = info.load_compiled_model;
-  load_compiled_path_ = info.load_model_file;
+  model_cache_path_ = info.model_cache_dir;
 
   exhaustive_tune_ = info.exhaustive_tune;
 
@@ -236,28 +234,10 @@ void MIGraphXExecutionProvider::get_flags_from_env() {
   }
 
   // Save/load migraphx compiled models
-  const std::string save_comp_model_env = onnxruntime::GetEnvironmentVar(migraphx_env_vars::kSaveCompiledModel);
-  if (!save_comp_model_env.empty()) {
-    save_compiled_model_ = (std::stoi(save_comp_model_env) == 0 ? false : true);
-    LOGS_DEFAULT(WARNING) << "\nORT_MIGRAPHX_SAVE_COMPILED_MODEL: " << save_compiled_model_;
-  }
-
-  const std::string save_model_path_env = onnxruntime::GetEnvironmentVar(migraphx_env_vars::kSavedModelPath);
-  if (save_compiled_model_ && !save_model_path_env.empty()) {
-    save_compiled_path_ = save_model_path_env;
-    LOGS_DEFAULT(WARNING) << "\nORT_MIGRAPHX_SAVE_COMPILED_PATH: " << save_compiled_path_;
-  }
-
-  const std::string load_comp_model_env = onnxruntime::GetEnvironmentVar(migraphx_env_vars::kLoadCompiledModel);
-  if (!load_comp_model_env.empty()) {
-    load_compiled_model_ = (std::stoi(load_comp_model_env) == 0 ? false : true);
-    LOGS_DEFAULT(WARNING) << "\nORT_MIGRAPHX_LOAD_COMPILED_MODEL: " << load_compiled_model_;
-  }
-
-  const std::string load_model_path_env = onnxruntime::GetEnvironmentVar(migraphx_env_vars::kLoadModelPath);
-  if (load_compiled_model_ && !load_model_path_env.empty()) {
-    load_compiled_path_ = load_model_path_env;
-    LOGS_DEFAULT(WARNING) << "\nORT_MIGRAPHX_LOAD_COMPILED_PATH: " << load_compiled_path_;
+  const auto model_cache_path_env = GetEnvironmentVar(migraphx_env_vars::kModelCachePath);
+  if (!model_cache_path_env.empty()) {
+    model_cache_path_ = GetEnvironmentVar(migraphx_env_vars::kModelCachePath);
+    LOGS_DEFAULT(INFO) << "\n" << migraphx_env_vars::kModelCachePath << ": " << model_cache_path_;
   }
 
   // dump unsupported ops
@@ -285,10 +265,7 @@ void MIGraphXExecutionProvider::print_migraphx_ep_flags() {
                         << "\n " << migraphx_provider_option::kInt8CalibTable << ": " << int8_calibration_cache_name_
                         << "\n int8_calibration_cache_available: " << int8_calibration_cache_available_
                         << "\n " << migraphx_provider_option::kInt8UseNativeCalibTable << ": " << int8_use_native_migraphx_calibration_table_
-                        << "\n " << migraphx_provider_option::kSaveCompiledModel << ": " << save_compiled_model_
-                        << "\n " << migraphx_provider_option::kSaveModelPath << ": " << save_compiled_path_
-                        << "\n " << migraphx_provider_option::kLoadCompiledModel << ": " << load_compiled_model_
-                        << "\n " << migraphx_provider_option::kLoadModelPath << ": " << load_compiled_path_;
+                        << "\n " << migraphx_provider_option::kModelCacheDir << ": " << model_cache_path_;
 }
 
 AllocatorPtr MIGraphXExecutionProvider::CreateMIGraphXAllocator(OrtDevice::DeviceId device_id,
@@ -1241,29 +1218,26 @@ bool get_input_output_names(const GraphViewer& graph,
 
 // Attempt to load a model and catch any exceptions on load fail.
 // Useful to default to EP to trigger the compile if file doesn't exist or loading fails.
-bool load_precompiled_model(migraphx::program& prog, bool load_enable, std::string path) {
+bool load_precompiled_model(migraphx::program& prog, const std::filesystem::path& path)
   try {
-    if (load_enable) {
-      LOGS_DEFAULT(INFO) << "Attempting to load model at:" << path;
-      prog = migraphx::load(path.c_str());
+    if (!path.empty() && exists(path)) {
+      LOGS_DEFAULT(INFO) << "Attempting to load model at:" << path.string();
+      prog = migraphx::load(path.string().c_str());
       LOGS_DEFAULT(INFO) << "load model : Success";
       return true;
-    } else {
-      return false;
     }
+    return false;
   } catch (...) {
     return false;
   }
-  return false;
-}
 
-void save_compiled_model(migraphx::program& prog, bool save_enable, std::string out_path) {
-  if (save_enable) {
-    LOGS_DEFAULT(WARNING) << "Model Save at " << out_path << ": Begin";
+void save_compiled_model(const migraphx::program& prog, const std::filesystem::path& path) {
+  if (!path.empty()) {
+    LOGS_DEFAULT(INFO) << "Model Save at " << path << ": Begin";
     migraphx::file_options fo;
     fo.set_file_format("msgpack");
-    migraphx::save(prog, out_path.c_str(), fo);
-    LOGS_DEFAULT(WARNING) << "Model Save: Complete";
+    save(prog, path.string().c_str(), fo);
+    LOGS_DEFAULT(INFO) << "Model Save: Complete";
   }
 }
 
@@ -1328,6 +1302,25 @@ void compile_program(migraphx::program& prog,
   LOGS_DEFAULT(WARNING) << "Model Compile: Complete";
 }
 
+std::string to_hex(const uint64_t v) {
+  std::array<char, sizeof v << 1> s{};
+  auto [ptr, _] = std::to_chars(s.data(), s.data() + s.size(), v, 16);
+  return std::string{s.data(), ptr};
+}
+
+template <typename T> std::string make_hash(T v) {
+  std::array<std::uint32_t, 4> temp{};
+  MurmurHash3::x86_128(v.data(), gsl::narrow_cast<int32_t>(v.size()), temp[0], temp.data());
+  return to_hex(temp[0] | static_cast<uint64_t>(temp[1]) << 32);
+}
+
+template <> std::string make_hash(const char* v) {
+  return make_hash(std::string_view{v});
+}
+
+constexpr std::uint64_t MIGraphX_Version =
+  ((MIGRAPHX_VERSION_MAJOR << 16) | (MIGRAPHX_VERSION_MINOR << 8) | MIGRAPHX_VERSION_PATCH);
+
 Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& fused_nodes,
                                           std::vector<NodeComputeInfo>& node_compute_funcs) {
   migraphx::onnx_options options;
@@ -1335,6 +1328,33 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
   for (const auto& fused_node_graph : fused_nodes) {
     const GraphViewer& graph_body_viewer = fused_node_graph.filtered_graph;
     const Node& fused_node = fused_node_graph.fused_node;
+
+    std::filesystem::path model_cache_file;
+    auto mxr_filename_prefix = to_hex(MIGraphX_Version) + "-" + GenerateGraphId(graph_body_viewer) + "-" + make_hash(std::string_view(device_prop_.gcnArchName)) + "-";
+
+    // Get model input names (only first layer)
+    const Graph* cur_graph = &graph_body_viewer.GetGraph();
+    while (cur_graph->IsSubgraph()) {
+      cur_graph = cur_graph->ParentGraph();
+    }
+    const Graph& main_graph = *cur_graph;
+    const auto& input_tensor = main_graph.GetInputs();
+    for (auto i : input_tensor) {
+      session_input_names.insert(i->Name());
+    }
+
+    // empty cache path means the MXR caching is disabled - always compile
+    if (!model_cache_path_.empty()) {
+      std::vector<std::int64_t> input_shapes;
+      for (std::size_t i = 0; i < session_input_names.size(); ++i) {
+        auto tensor_shape = input_tensor[i]->Shape();
+        for (int j = 1; j < tensor_shape->dim_size(); ++j) {
+          input_shapes.push_back(tensor_shape->dim(j).dim_value());
+        }
+      }
+      model_cache_file = model_cache_path_ / (mxr_filename_prefix + make_hash(input_shapes) + ".mxr");
+    }
+
     // map parameter input name to index
     std::unordered_map<std::string, std::size_t> input_name_index;
     const auto& input_defs = fused_node.InputDefs();
@@ -1365,7 +1385,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
     migraphx::program prog;
 
     if (!no_input_shape) {
-      if (!load_precompiled_model(prog, load_compiled_model_, std::string{load_compiled_path_})) {
+      if (!load_precompiled_model(prog, model_cache_file)) {
         LOGS_DEFAULT(INFO) << "No input shapes detected quantizing model";
 #ifndef ENABLE_TRAINING_CORE
 #ifdef HAVE_MIGRAPHX_API_ONNX_OPTIONS_SET_EXTERNAL_DATA_PATH
@@ -1378,7 +1398,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         calibrate_and_quantize(prog, t_, quant_params, fp16_enable_, int8_enable_,
                                fp8_enable_, int8_calibration_cache_available_, dynamic_range_map_);
         compile_program(prog, t_, exhaustive_tune_);
-        save_compiled_model(prog, save_compiled_model_, save_compiled_path_);
+        save_compiled_model(prog, model_cache_file);
       }
 
       auto prog_output_shapes = prog.get_output_shapes();
@@ -1401,8 +1421,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
             map_onnx_string_[context->node_name], options, t_, map_input_index_[context->node_name], &mgx_mu_,
             map_no_input_shape_[context->node_name], fp16_enable_, fp8_enable_, int8_enable_,
             int8_calibration_cache_available_, dynamic_range_map_,
-            save_compiled_model_, save_compiled_path_,
-            load_compiled_model_, load_compiled_path_, dump_model_ops_};
+            model_cache_path_.string(), dump_model_ops_};
       *state = p.release();
       return 0;
     };
@@ -1412,7 +1431,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
         delete static_cast<MIGraphXFuncState*>(state);
     };
 
-    compute_info.compute_func = [this](FunctionState state, const OrtApi* api, OrtKernelContext* context) {
+    compute_info.compute_func = [this, mxr_filename_prefix](FunctionState state, const OrtApi* api, OrtKernelContext* context) {
       Ort::KernelContext ctx(context);
       MIGraphXFuncState* mgx_state = reinterpret_cast<MIGraphXFuncState*>(state);
 
@@ -1432,6 +1451,8 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       // from input data
       bool input_shape_match = true;
       migraphx::program_parameter_shapes param_shapes;
+      std::vector<std::int64_t> input_shapes;
+
       if (no_input_shape) {
         LOGS_DEFAULT(INFO) << "Missing input shape setting input parameters again";
         for (auto& it : map_input_name_index) {
@@ -1471,6 +1492,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
                 cmp_options.set_input_parameter_shape(name, ort_lens);
                 input_shape_match = false;
               }
+              input_shapes.insert(input_shapes.end(), tensor_shape.begin(), tensor_shape.end());
             }
           }
         }
@@ -1479,8 +1501,13 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       // input shapes are different, needs to re-parse onnx and
       // re-compile the program
       if (!input_shape_match) {
-        if (!load_precompiled_model(prog, load_compiled_model_, std::string{load_compiled_path_})) {
-          LOGS_DEFAULT(VERBOSE) << "Input shape mismatch detected. Recompiling" << std::endl;
+        std::filesystem::path model_cache_file;
+        // empty cache path means the MXR caching is disabled - always compile
+        if (!model_cache_path_.empty()) {
+          model_cache_file = mgx_state->model_cache_dir / (mxr_filename_prefix + make_hash(input_shapes) + ".mxr");
+        }
+        if (!load_precompiled_model(prog, model_cache_file)) {
+          LOGS_DEFAULT(VERBOSE) << "Input shape mismatch detected. Recompiling";
 #ifndef ENABLE_TRAINING_CORE
 #ifdef HAVE_MIGRAPHX_API_ONNX_OPTIONS_SET_EXTERNAL_DATA_PATH
           cmp_options.set_external_data_path(model_path_.parent_path().string());
@@ -1513,7 +1540,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           calibrate_and_quantize(prog, t, quant_params, fp16_enable, int8_enable,
                                  fp8_enable, int8_calibration_cache_available, map_dynamic_range);
           compile_program(prog, t, exhaustive_tune_);
-          save_compiled_model(prog, mgx_state->save_compiled_mode, mgx_state->save_compiled_path);
+          save_compiled_model(prog, model_cache_file);
         }
 
         mgx_state->prog = prog;

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <set>
 #include "core/framework/arena_extend_strategy.h"
 #include "core/framework/execution_provider.h"
 #include <mutex>
@@ -23,10 +24,7 @@ constexpr auto kDumpModelOps = "ORT_MIGRAPHX_DUMP_MODEL_OPS";
 constexpr auto kINT8CalibrationTableName = "ORT_MIGRAPHX_INT8_CALIBRATION_TABLE_NAME";
 constexpr auto kCachePath = "ORT_MIGRAPHX_CACHE_PATH";
 constexpr auto kINT8UseNativeMIGraphXCalibrationTable = "ORT_MIGRAPHX_INT8_USE_NATIVE_CALIBRATION_TABLE";
-constexpr auto kSaveCompiledModel = "ORT_MIGRAPHX_SAVE_COMPILED_MODEL";
-constexpr auto kSavedModelPath = "ORT_MIGRAPHX_SAVE_COMPILED_PATH";
-constexpr auto kLoadCompiledModel = "ORT_MIGRAPHX_LOAD_COMPILED_MODEL";
-constexpr auto kLoadModelPath = "ORT_MIGRAPHX_LOAD_COMPILED_PATH";
+constexpr auto kModelCachePath = "ORT_MIGRAPHX_MODEL_CACHE_PATH";
 constexpr auto kExhaustiveTune = "ORT_MIGRAPHX_EXHAUSTIVE_TUNE";
 
 }  // namespace migraphx_env_vars
@@ -48,10 +46,7 @@ struct MIGraphXFuncState {
   bool int8_enable = false;
   bool int8_calibration_cache_available = false;
   std::unordered_map<std::string, float> dynamic_range_map;
-  bool save_compiled_mode = false;
-  std::string save_compiled_path;
-  bool load_compiled_mode = false;
-  std::string load_compiled_path;
+  std::filesystem::path model_cache_dir;
   bool dump_model_ops = false;
   bool exhaustive_tune = false;
 };
@@ -107,14 +102,13 @@ class MIGraphXExecutionProvider : public IExecutionProvider {
   bool int8_use_native_migraphx_calibration_table_ = false;
   std::string calibration_cache_path_;
   std::unordered_map<std::string, float> dynamic_range_map_;
-  bool save_compiled_model_ = false;
-  std::string save_compiled_path_;
-  bool load_compiled_model_ = false;
-  std::string load_compiled_path_;
+  std::filesystem::path model_cache_path_{};
+  std::set<std::string> session_input_names;
   bool dump_model_ops_ = false;
   migraphx::target t_;
   std::mutex mgx_mu_;
   hipStream_t stream_ = nullptr;
+  hipDeviceProp_t device_prop_;
   bool exhaustive_tune_ = false;
   mutable std::filesystem::path model_path_;
 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
@@ -63,8 +63,7 @@ MIGraphXExecutionProviderInfo MIGraphXExecutionProviderInfo::FromProviderOptions
           .AddAssignmentToReference(migraphx_provider_option::kFp16Enable, info.fp16_enable)
           .AddAssignmentToReference(migraphx_provider_option::kFp8Enable, info.fp8_enable)
           .AddAssignmentToReference(migraphx_provider_option::kInt8Enable, info.int8_enable)
-          .AddAssignmentToReference(migraphx_provider_option::kSaveCompiledModel, info.save_compiled_model)
-          .AddAssignmentToReference(migraphx_provider_option::kLoadCompiledModel, info.load_compiled_model)
+          .AddAssignmentToReference(migraphx_provider_option::kModelCacheDir, info.model_cache_dir)
           .AddAssignmentToReference(migraphx_provider_option::kExhaustiveTune, info.exhaustive_tune)
           .AddAssignmentToReference(migraphx_provider_option::kMemLimit, info.mem_limit)
           .AddAssignmentToEnumReference(migraphx_provider_option::kArenaExtendStrategy, arena_extend_strategy_mapping, info.arena_extend_strategy)
@@ -82,8 +81,7 @@ ProviderOptions MIGraphXExecutionProviderInfo::ToProviderOptions(const MIGraphXE
       {migraphx_provider_option::kFp16Enable, MakeStringWithClassicLocale(info.fp16_enable)},
       {migraphx_provider_option::kFp8Enable, MakeStringWithClassicLocale(info.fp8_enable)},
       {migraphx_provider_option::kInt8Enable, MakeStringWithClassicLocale(info.int8_enable)},
-      {migraphx_provider_option::kSaveCompiledModel, MakeStringWithClassicLocale(info.save_compiled_model)},
-      {migraphx_provider_option::kLoadCompiledModel, MakeStringWithClassicLocale(info.load_compiled_model)},
+      {migraphx_provider_option::kModelCacheDir, MakeStringWithClassicLocale(info.model_cache_dir)},
       {migraphx_provider_option::kMemLimit, MakeStringWithClassicLocale(info.mem_limit)},
       {migraphx_provider_option::kGpuExternalAlloc, MakeStringWithClassicLocale(reinterpret_cast<size_t>(info.external_allocator_info.alloc))},
       {migraphx_provider_option::kGpuExternalFree, MakeStringWithClassicLocale(reinterpret_cast<size_t>(info.external_allocator_info.free))},
@@ -100,8 +98,7 @@ ProviderOptions MIGraphXExecutionProviderInfo::ToProviderOptions(const OrtMIGrap
       {migraphx_provider_option::kFp16Enable, MakeStringWithClassicLocale(info.migraphx_fp16_enable)},
       {migraphx_provider_option::kFp8Enable, MakeStringWithClassicLocale(info.migraphx_fp8_enable)},
       {migraphx_provider_option::kInt8Enable, MakeStringWithClassicLocale(info.migraphx_int8_enable)},
-      {migraphx_provider_option::kSaveCompiledModel, MakeStringWithClassicLocale(info.migraphx_save_compiled_model)},
-      {migraphx_provider_option::kLoadCompiledModel, MakeStringWithClassicLocale(info.migraphx_load_compiled_model)},
+      {migraphx_provider_option::kModelCacheDir, MakeStringWithClassicLocale(info.migraphx_cache_dir)},
       {migraphx_provider_option::kMemLimit, MakeStringWithClassicLocale(info.migraphx_mem_limit)},
       {migraphx_provider_option::kArenaExtendStrategy, EnumToName(arena_extend_strategy_mapping, static_cast<onnxruntime::ArenaExtendStrategy>(info.migraphx_arena_extend_strategy))},
       {migraphx_provider_option::kExhaustiveTune, MakeStringWithClassicLocale(info.migraphx_exhaustive_tune)},

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
@@ -39,7 +39,7 @@ MIGraphXExecutionProviderInfo MIGraphXExecutionProviderInfo::FromProviderOptions
           .AddValueParser(
               migraphx_provider_option::kGpuExternalAlloc,
               [&alloc](const std::string& value_str) -> Status {
-                size_t address;
+                std::uintptr_t address;
                 ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, address));
                 alloc = reinterpret_cast<void*>(address);
                 return Status::OK();
@@ -47,7 +47,7 @@ MIGraphXExecutionProviderInfo MIGraphXExecutionProviderInfo::FromProviderOptions
           .AddValueParser(
               migraphx_provider_option::kGpuExternalFree,
               [&free](const std::string& value_str) -> Status {
-                size_t address;
+                std::uintptr_t address;
                 ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, address));
                 free = reinterpret_cast<void*>(address);
                 return Status::OK();
@@ -55,7 +55,7 @@ MIGraphXExecutionProviderInfo MIGraphXExecutionProviderInfo::FromProviderOptions
           .AddValueParser(
               migraphx_provider_option::kGpuExternalEmptyCache,
               [&empty_cache](const std::string& value_str) -> Status {
-                size_t address;
+                std::uintptr_t address;
                 ORT_RETURN_IF_ERROR(ParseStringWithClassicLocale(value_str, address));
                 empty_cache = reinterpret_cast<void*>(address);
                 return Status::OK();

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.h
@@ -21,10 +21,7 @@ constexpr auto kFp8Enable = "migraphx_fp8_enable";
 constexpr auto kInt8Enable = "migraphx_int8_enable";
 constexpr auto kInt8CalibTable = "migraphx_int8_calibration_table_name";
 constexpr auto kInt8UseNativeCalibTable = "migraphx_int8_use_native_calibration_table";
-constexpr auto kSaveCompiledModel = "migraphx_save_compiled_model";
-constexpr auto kSaveModelPath = "migraphx_save_model_name";
-constexpr auto kLoadCompiledModel = "migraphx_load_compiled_model";
-constexpr auto kLoadModelPath = "migraphx_load_model_name";
+constexpr auto kModelCacheDir = "migraphx_model_cache_dir";
 constexpr auto kExhaustiveTune = "migraphx_exhaustive_tune";
 constexpr auto kMemLimit = "migraphx_mem_limit";
 constexpr auto kArenaExtendStrategy = "migraphx_arena_extend_strategy";
@@ -65,10 +62,7 @@ struct MIGraphXExecutionProviderInfo {
   bool int8_enable{false};
   std::string int8_calibration_table_name{""};
   bool int8_use_native_calibration_table{false};
-  bool save_compiled_model{false};
-  std::string save_model_file{""};
-  bool load_compiled_model{false};
-  std::string load_model_file{""};
+  std::filesystem::path model_cache_dir{};
   bool exhaustive_tune{false};
 
   size_t mem_limit{std::numeric_limits<size_t>::max()};                             // Will be over-ridden by contents of `default_memory_arena_cfg` (if specified)
@@ -94,11 +88,13 @@ struct std::hash<::onnxruntime::MIGraphXExecutionProviderInfo> {
                   (static_cast<size_t>(info.fp16_enable) << 18) ^
                   (static_cast<size_t>(info.int8_enable) << 19) ^
                   (static_cast<size_t>(info.int8_use_native_calibration_table) << 20) ^
-                  (static_cast<size_t>(info.save_compiled_model) << 21) ^
-                  (static_cast<size_t>(info.load_compiled_model) << 22) ^
-                  (static_cast<size_t>(info.exhaustive_tune) << 23);
+                  (static_cast<size_t>(info.exhaustive_tune) << 21);
     onnxruntime::HashCombine(data, value);
 
+    onnxruntime::HashCombine(info.target_device, value);
+    onnxruntime::HashCombine(info.default_memory_arena_cfg, value);
+    onnxruntime::HashCombine(info.int8_calibration_table_name, value);
+    onnxruntime::HashCombine(info.model_cache_dir, value);
     onnxruntime::HashCombine(info.mem_limit, value);
 
     // Memory pointers

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
@@ -293,7 +293,7 @@ inline std::string GenerateGraphId(const GraphViewer& graph_viewer) {
     hash_str(node_arg->Name());
   }
 
-  // hashing output of each node
+  // hashing outputs, inputs and inputs shapes of each node
   const int number_of_ort_nodes = graph_viewer.NumberOfNodes();
   std::vector<size_t> nodes_vector(number_of_ort_nodes);
   std::iota(std::begin(nodes_vector), std::end(nodes_vector), 0);
@@ -303,6 +303,15 @@ inline std::string GenerateGraphId(const GraphViewer& graph_viewer) {
     for (const auto* node_arg : node->OutputDefs()) {
       if (node_arg->Exists()) {
         hash_str(node_arg->Name());
+      }
+    }
+    for (const auto* node_arg : node->InputDefs()) {
+      if (node_arg->Exists()) {
+        hash_str(node_arg->Name());
+        int dim_size = node_arg->Shape()->dim_size();
+        for (int i = 0; i < dim_size; i++) {
+          hash_str(std::to_string(node_arg->Shape()->dim(i).dim_value()));
+        }
       }
     }
   }

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
@@ -192,7 +192,7 @@ inline bool ReadDynamicRange(const std::string file_name,
                              std::unordered_map<std::string,
                                                 float>& dynamic_range_map) {
   std::ifstream infile(file_name, std::ios::binary | std::ios::in);
-  if (!infile) {
+  if (!infile.good()) {
     return false;
   }
 

--- a/onnxruntime/core/providers/migraphx/migraphx_inc.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_inc.h
@@ -5,4 +5,5 @@
 
 #include <hip/hip_runtime.h>
 #include <iso646.h>
+#include <migraphx/version.h>
 #include <migraphx/migraphx.hpp>

--- a/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License
 #include <atomic>
+#include <string>
 
 #include "core/providers/shared_library/provider_api.h"
 #include "core/providers/migraphx/migraphx_provider_factory.h"
@@ -90,15 +91,9 @@ struct MIGraphX_Provider : Provider {
       info.int8_calibration_table_name = options.migraphx_int8_calibration_table_name;
     }
     info.int8_use_native_calibration_table = options.migraphx_use_native_calibration_table != 0;
-    info.save_compiled_model = options.migraphx_save_compiled_model;
-    info.save_model_file = "";
-    if (options.migraphx_save_model_path != nullptr) {
-      info.save_model_file = options.migraphx_save_model_path;
-    }
-    info.load_compiled_model = options.migraphx_load_compiled_model;
-    info.load_model_file = "";
-    if (options.migraphx_load_model_path != nullptr) {
-      info.load_model_file = options.migraphx_load_model_path;
+    info.model_cache_dir = "";
+    if (options.migraphx_cache_dir != nullptr) {
+      info.model_cache_dir = options.migraphx_cache_dir;
     }
     info.arena_extend_strategy = static_cast<onnxruntime::ArenaExtendStrategy>(options.migraphx_arena_extend_strategy);
     info.mem_limit = options.migraphx_mem_limit;
@@ -131,10 +126,7 @@ struct MIGraphX_Provider : Provider {
 
     migx_options.migraphx_use_native_calibration_table = internal_options.int8_use_native_calibration_table;
 
-    migx_options.migraphx_save_compiled_model = internal_options.save_compiled_model;
-    migx_options.migraphx_save_model_path = internal_options.save_model_file.c_str();
-    migx_options.migraphx_load_compiled_model = internal_options.load_compiled_model;
-    migx_options.migraphx_load_model_path = internal_options.load_model_file.c_str();
+    migx_options.migraphx_cache_dir = internal_options.model_cache_dir.string().c_str();
     migx_options.migraphx_arena_extend_strategy = static_cast<int>(internal_options.arena_extend_strategy);
     migx_options.migraphx_mem_limit = internal_options.mem_limit;
   }

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -848,7 +848,7 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
 #endif
   } else if (type == kMIGraphXExecutionProvider) {
 #ifdef USE_MIGRAPHX
-    std::string model_cache_path;
+    std::string model_cache_path, cal_table_name;
     auto it = provider_options_map.find(type);
     if (it != provider_options_map.end()) {
       OrtMIGraphXProviderOptions params{
@@ -901,7 +901,8 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
           }
         } else if (option.first == migraphx_provider_option::kInt8CalibTable) {
           if (!option.second.empty()) {
-            params.migraphx_int8_calibration_table_name = option.second.c_str();
+            cal_table_name = option.second;
+            params.migraphx_int8_calibration_table_name = cal_table_name.c_str();
           } else {
             ORT_THROW(
                 "[ERROR] [MIGraphX] The value for the key 'migraphx_int8_calibration_table_name' should be a "

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -848,6 +848,7 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
 #endif
   } else if (type == kMIGraphXExecutionProvider) {
 #ifdef USE_MIGRAPHX
+    std::string model_cache_path;
     auto it = provider_options_map.find(type);
     if (it != provider_options_map.end()) {
       OrtMIGraphXProviderOptions params{
@@ -857,10 +858,7 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
           0,
           0,
           nullptr,
-          0,
-          "./compiled_model.mxr",
-          0,
-          "./compiled_model.mxr",
+          nullptr,
           false,
           SIZE_MAX,
           0};
@@ -919,37 +917,10 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
                 "[ERROR] [MIGraphX] The value for the key 'migraphx_use_native_calibration_table' should be"
                 " 'True' or 'False'. Default value is 'False'.\n");
           }
-        } else if (option.first == migraphx_provider_option::kSaveCompiledModel) {
-          if (option.second == "True" || option.second == "true") {
-            params.migraphx_save_compiled_model = true;
-          } else if (option.second == "False" || option.second == "false") {
-            params.migraphx_save_compiled_model = false;
-          } else {
-            ORT_THROW(
-                "[ERROR] [MIGraphX] The value for the key 'migraphx_save_compiled_model' should be"
-                " 'True' or 'False'. Default value is 'False'.\n");
-          }
-        } else if (option.first == migraphx_provider_option::kSaveModelPath) {
+        } else if (option.first == migraphx_provider_option::kModelCacheDir) {
           if (!option.second.empty()) {
-            params.migraphx_save_model_path = option.second.c_str();
-          } else {
-            ORT_THROW(
-                "[ERROR] [MIGraphX] The value for the key 'migraphx_save_model_name' should be a "
-                "file name i.e. 'compiled_model.mxr'.\n");
-          }
-        } else if (option.first == migraphx_provider_option::kLoadCompiledModel) {
-          if (option.second == "True" || option.second == "true") {
-            params.migraphx_load_compiled_model = true;
-          } else if (option.second == "False" || option.second == "false") {
-            params.migraphx_load_compiled_model = false;
-          } else {
-            ORT_THROW(
-                "[ERROR] [MIGraphX] The value for the key 'migraphx_load_compiled_model' should be"
-                " 'True' or 'False'. Default value is 'False'.\n");
-          }
-        } else if (option.first == migraphx_provider_option::kLoadModelPath) {
-          if (!option.second.empty()) {
-            params.migraphx_load_model_path = option.second.c_str();
+            model_cache_path = option.second;
+            params.migraphx_cache_dir = model_cache_path.c_str();
           } else {
             ORT_THROW(
                 "[ERROR] [MIGraphX] The value for the key 'migraphx_load_model_name' should be a "

--- a/onnxruntime/test/util/default_providers.cc
+++ b/onnxruntime/test/util/default_providers.cc
@@ -79,10 +79,7 @@ std::unique_ptr<IExecutionProvider> DefaultMIGraphXExecutionProvider() {
       0,
       0,
       nullptr,
-      1,
-      "./compiled_model.mxr",
-      1,
-      "./compiled_model.mxr",
+      nullptr,
       1,
       SIZE_MAX,
       0};


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

ROCm 6.4 promoted Cherry-picks
#88   - Adds integer pointer type to be cleear on what sused here. Gives better portability and clarity than size_t 
#110  - fixes issue foudn with calibration table loading for int8/fp8/staticly quantized types
#105  - Updates save/load functionality and simples this feature under one flag
#109  - Add support patch for Clang20 for staging builds
#112  - Update has to include input arguments and model name to avoid mxr name hash collisions


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Bugfix + cleanup of workflow and flags.

The bugfix is critical as it allows us to use our pybind interface without the risk of undefined behavior with statically quantized data inputs. 

