### PR TITLE
Adding hash input names and shapes to get unique graphx hash

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
@@ -293,7 +293,7 @@ inline std::string GenerateGraphId(const GraphViewer& graph_viewer) {
     hash_str(node_arg->Name());
   }
 
-  // hashing output of each node
+  // hashing outputs, inputs and inputs shapes of each node
   const int number_of_ort_nodes = graph_viewer.NumberOfNodes();
   std::vector<size_t> nodes_vector(number_of_ort_nodes);
   std::iota(std::begin(nodes_vector), std::end(nodes_vector), 0);
@@ -303,6 +303,15 @@ inline std::string GenerateGraphId(const GraphViewer& graph_viewer) {
     for (const auto* node_arg : node->OutputDefs()) {
       if (node_arg->Exists()) {
         hash_str(node_arg->Name());
+      }
+    }
+    for (const auto* node_arg : node->InputDefs()) {
+      if (node_arg->Exists()) {
+        hash_str(node_arg->Name());
+        int dim_size = node_arg->Shape()->dim_size();
+        for (int i = 0; i < dim_size; i++) {
+          hash_str(std::to_string(node_arg->Shape()->dim(i).dim_value()));
+        }
       }
     }
   }


### PR DESCRIPTION
Adding hash for inputs and inputs' shapes into graph hashing in order to make unique graph hash for each model. We noticed that some LLM models have the same graph structure which causes the problem with the same mxr names for different models saved during first inference which may cause a problem in future runs. If we save only hash of node output names, which was the case before changes, it may happen that we got the same graph hash for different models (for example Llama2, Mistral, Llama3). For that reason, now we have an additional hash information about node input names and their shapes in order to prevent these situations. The mxr name convention is the same like before: 
`hash(MIGraphX version) + hash(Graph) + hash(gfx version) + hash(input shapes)` .


