### PR TITLE
Align path for fused_ops cpp extension to resolve discrapency between different platforms

### DIFF
--- a/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cuda/fused_ops/setup.py
+++ b/orttraining/orttraining/python/training/ortmodule/torch_cpp_extensions/cuda/fused_ops/setup.py
@@ -10,12 +10,15 @@ import sys  # noqa: F401
 from setuptools import setup
 from torch.utils import cpp_extension
 
+# Resolve symlink in path to fix discrepancy between platforms
+fused_ops_dir = os.path.realpath(os.path.dirname(__file__))
+
 filenames = [
-    os.path.join(os.path.dirname(__file__), "fused_ops_frontend.cpp"),
-    os.path.join(os.path.dirname(__file__), "multi_tensor_adam.cu"),
-    os.path.join(os.path.dirname(__file__), "multi_tensor_scale_kernel.cu"),
-    os.path.join(os.path.dirname(__file__), "multi_tensor_axpby_kernel.cu"),
-    os.path.join(os.path.dirname(__file__), "multi_tensor_l2norm_kernel.cu"),
+    os.path.join(fused_ops_dir, "fused_ops_frontend.cpp"),
+    os.path.join(fused_ops_dir, "multi_tensor_adam.cu"),
+    os.path.join(fused_ops_dir, "multi_tensor_scale_kernel.cu"),
+    os.path.join(fused_ops_dir, "multi_tensor_axpby_kernel.cu"),
+    os.path.join(fused_ops_dir, "multi_tensor_l2norm_kernel.cu"),
 ]
 
 use_rocm = bool(os.environ["ONNXRUNTIME_ROCM_VERSION"])


### PR DESCRIPTION

### Description
Getting path for fused_ops cpp extension updated to resolve symlink when setting file path.



### Motivation and Context
Fixing path discrepancy between different platform (RHEL, Ubuntu) since some are using file paths with symlinks and some real paths. File paths are now aligned, and all platforms use real path without symlinks.


