### PR TITLE
Add null check for unique graphx hash

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
@@ -301,12 +301,12 @@ inline std::string GenerateGraphId(const GraphViewer& graph_viewer) {
   for (const auto& index : nodes_vector) {
     const auto& node = graph_viewer.GetNode(node_index[index]);
     for (const auto* node_arg : node->OutputDefs()) {
-      if (node_arg->Exists()) {
+      if (node_arg != nullptr && node_arg->Exists()) {
         hash_str(node_arg->Name());
       }
     }
     for (const auto* node_arg : node->InputDefs()) {
-      if (node_arg->Exists()) {
+      if (node_arg != nullptr && node_arg->Exists()) {
         hash_str(node_arg->Name());
         int dim_size = node_arg->Shape()->dim_size();
         for (int i = 0; i < dim_size; i++) {

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
@@ -308,6 +308,9 @@ inline std::string GenerateGraphId(const GraphViewer& graph_viewer) {
     for (const auto* node_arg : node->InputDefs()) {
       if (node_arg != nullptr && node_arg->Exists()) {
         hash_str(node_arg->Name());
+        if (node_arg->Shape() == nullptr) {
+          continue;
+        }
         int dim_size = node_arg->Shape()->dim_size();
         for (int i = 0; i < dim_size; i++) {
           hash_str(std::to_string(node_arg->Shape()->dim(i).dim_value()));


### PR DESCRIPTION
Adding null checks for node args and its properties when creating unique graphx hash.


