### PR TITLE
Update build args to include rocm_gfx_arch input for ROCM/MIGraphX EP…

### DIFF
--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -717,6 +717,7 @@ def generate_build_tree(
     if args.use_rocm:
         cmake_args.append("-Donnxruntime_ROCM_HOME=" + rocm_home)
         cmake_args.append("-Donnxruntime_ROCM_VERSION=" + args.rocm_version)
+        cmake_args.append("-DCMAKE_HIP_ARCHITECTURES=" + args.rocm_gfx_arch)
     if args.use_tensorrt or args.use_nv_tensorrt_rtx:
         cmake_args.append("-Donnxruntime_TENSORRT_HOME=" + tensorrt_home)
 

--- a/tools/ci_build/build_args.py
+++ b/tools/ci_build/build_args.py
@@ -608,6 +608,8 @@ def add_execution_provider_args(parser: argparse.ArgumentParser) -> None:
     rocm_group.add_argument("--use_rocm", action="store_true", help="Enable ROCm EP.")
     rocm_group.add_argument("--rocm_version", help="ROCm stack version.")
     rocm_group.add_argument("--rocm_home", help="Path to ROCm installation directory.")
+    rocm_group.add_argument("--rocm_gfx_arch", help='Provide gfx arch. Example --rocm_gfx_arch gfx942' 
+            ' or --rocm_gfx_arch "gfx90a;gfx942"')
     # ROCm-specific profiling
     rocm_group.add_argument(
         "--enable_rocm_profiling",


### PR DESCRIPTION
… builds

### Description
<!-- Describe your changes. -->
Adds back in rocm_gfx_arch input for the builds of MIGraphX/ROCm Ep runs


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

Need this as we use this flag in our QA/Dev ops build cycle when generating Onnxruntime wheels

This never was upstreamed earlier and then changes to Onnxruntime 1.22 sync changed the build sytem that caused a failure for compile of ROCm 7.0 builds