### PR TITLE
Update GPU_WARP_SIZE to macro instead of using hip api warpSize constexpr thats depricated in HIP 7.0

### DIFF
--- a/onnxruntime/core/providers/rocm/cu_inc/common.cuh
+++ b/onnxruntime/core/providers/rocm/cu_inc/common.cuh
@@ -576,8 +576,14 @@ struct alignas(sizeof(T) * vec_size) aligned_vector {
 // HIP_KERNEL_ASSERT is a macro that wraps an assert() call inside rocm kernels.
 #define HIP_KERNEL_ASSERT(...) assert(__VA_ARGS__)
 
+#if defined(__GFX9__)
+#define ROCM_EP_HIP_WAVEFRONT_SIZE 64
+#else
+#define ROCM_EP_HIP_WAVEFRONT_SIZE 32
+#endif
+
 // WARP related definitions and functions
-constexpr int GPU_WARP_SIZE = warpSize;
+constexpr int GPU_WARP_SIZE = ROCM_EP_HIP_WAVEFRONT_SIZE;
 inline int GPU_WARP_SIZE_HOST = warpSizeDynamic();
 
 template <typename T>


### PR DESCRIPTION


### Description
<!-- Describe your changes. -->
Remove the use of the warpSize const exprt and use macros for this based on gfx target right now.

Hip 7.0 deprecated use of warpSize and thus ROCm EP needs this fix in common kernel items to propagate throughout the build

More info found here; https://rocm.blogs.amd.com/ecosystems-and-partners/transition-to-hip-7.0:-guidance-on-upcoming-compatibility-changes/README.html#warpsize-change

Proposed solution: 
https://rocm.docs.amd.com/en/latest/about/release-notes.html#amdgpu-wavefront-size-compiler-macro-deprecation

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Need this so we can use ROCm HIP 7.0 API changes without breaking builds. 

