### PR TITLE
Add gfx1150 to supported HIP architectures

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -343,7 +343,7 @@ if (onnxruntime_USE_ROCM)
     if (ROCM_VERSION_DEV VERSION_LESS "6.2")
       message(FATAL_ERROR "CMAKE_HIP_ARCHITECTURES is not set when ROCm version < 6.2")
     else()
-      set(CMAKE_HIP_ARCHITECTURES "gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx942;gfx950;gfx1200;gfx1201")
+      set(CMAKE_HIP_ARCHITECTURES "gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx942;gfx950;gfx1200;gfx1201;gfx1150")
     endif()
   endif()
 


### PR DESCRIPTION
### Description
Adding gfx1150 to CMAKE_HIP_ARCHITECTURES

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->

To run MIGraphX EP with ROCm on a Linux gfx1150 system, "gfx1150" must be added to CMAKE_HIP_ARCHITECTURES.

Build recipe used inside AMDMIGraphX docker, /code/AMDMIGraphX is AMDMIGraphX repo mapped to docker:

pip3 install -r requirements-dev.txt
export PATH="/opt/cmake/bin:$PATH"
export CXXFLAGS="-D__HIP_PLATFORM_AMD__=1 -w"

./build.sh --build_shared_lib --config Release  --cmake_extra_defines CMAKE_PREFIX_PATH=/code/AMDMIGraphX/build \ CMAKE_INSTALL_PREFIX=`pwd`/install CMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ --update --build --build_wheel \ --parallel --cmake_extra_defines ONNXRUNTIME_VERSION=$(cat ./VERSION_NUMBER) --skip_tests --rocm_home /opt/rocm \ --use_migraphx --migraphx_home /code/AMDMIGraphX/build/ --rocm_version=`cat /opt/rocm/.info/version` --allow_running_as_root

cmake --install build/Linux/Release --config Release
