### PR TITLE
CK Fix for build failure seen with HIP 7.0 breaking changes

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -55,7 +55,7 @@ safeint;https://github.com/dcleblanc/SafeInt/archive/refs/tags/3.0.28.zip;23f252
 tensorboard;https://github.com/tensorflow/tensorboard/archive/373eb09e4c5d2b3cc2493f0949dc4be6b6a45e81.zip;67b833913605a4f3f499894ab11528a702c2b381
 cutlass;https://github.com/NVIDIA/cutlass/archive/refs/tags/v3.5.1.zip;e49b2b964163d27765a5002d210a2f3c73771835
 extensions;https://github.com/microsoft/onnxruntime-extensions/archive/c24b7bab0c12f53da76d0c31b03b9f0f8ec8f3b4.zip;239063aee4946a9af147b473a4c3da78ba7413b4
-composable_kernel;https://github.com/ROCmSoftwarePlatform/composable_kernel/archive/204da9c522cebec5220bba52cd3542ebcaf99e7a.zip;1827348efd47831c13074245274d41b7cae8a557
+composable_kernel;https://github.com/ROCm/composable_kernel/archive/5163b33ffbe57bf97176195028064cfd271a22b3.zip;85861422f99eaf8c44970c392db4bcfeee2c6cf8
 directx_headers;https://github.com/microsoft/DirectX-Headers/archive/refs/tags/v1.613.1.zip;47653509a3371eabb156360f42faf582f314bf2e
 cudnn_frontend;https://github.com/NVIDIA/cudnn-frontend/archive/refs/tags/v1.7.0.zip;d0753d8d5b39947ca0729d7773cb84653a129eb1
 dawn;https://github.com/google/dawn/archive/4cb1f9be152a4fa6bb695c08cd707ab078a1e2fb.zip;de39336b7715f53c14eec61072293b85cc73b691


### PR DESCRIPTION
### Description
Patch current CK (commit# 204da9c522cebec5220bba52cd3542ebcaf99e7a) used by onnxruntime to support HIP 7.0 changes



### Motivation and Context
Updating to latest amd-master of CK is blocked by different issues observed & seems need more time.
So far onnxruntime have been using CK commit # 204da9c522cebec5220bba52cd3542ebcaf99e7a & is working fine with it.
This PR patches that old CK commit to support HIP 7.0 changes



