### PR TITLE
Reduce number of log messages

### DIFF
--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.cc
@@ -1243,9 +1243,9 @@ bool get_input_output_names(const GraphViewer& graph,
 // Useful to default to EP to trigger the compile if file doesn't exist or loading fails.
 bool load_precompiled_model(migraphx::program& prog, const std::filesystem::path& path) try {
   if (!path.empty() && exists(path)) {
-    LOGS_DEFAULT(INFO) << "Attempting to load model at:" << path.string();
+    LOGS_DEFAULT(VERBOSE) << "Attempting to load model at:" << path.string();
     prog = migraphx::load(path.string().c_str());
-    LOGS_DEFAULT(INFO) << "load model : Success";
+    LOGS_DEFAULT(VERBOSE) << "load model : Success";
     return true;
   }
   return false;
@@ -1255,11 +1255,11 @@ bool load_precompiled_model(migraphx::program& prog, const std::filesystem::path
 
 void save_compiled_model(const migraphx::program& prog, const std::filesystem::path& path) {
   if (!path.empty()) {
-    LOGS_DEFAULT(INFO) << "Model Save at " << path << ": Begin";
+    LOGS_DEFAULT(VERBOSE) << "Model Save at " << path << ": Begin";
     migraphx::file_options fo;
     fo.set_file_format("msgpack");
     save(prog, path.string().c_str(), fo);
-    LOGS_DEFAULT(INFO) << "Model Save: Complete";
+    LOGS_DEFAULT(VERBOSE) << "Model Save: Complete";
   }
 }
 
@@ -1419,7 +1419,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
 
     if (!no_input_shape) {
       if (!load_precompiled_model(prog, model_cache_file)) {
-        LOGS_DEFAULT(INFO) << "No input shapes detected quantizing model";
+        LOGS_DEFAULT(VERBOSE) << "No input shapes detected quantizing model";
 #ifndef ENABLE_TRAINING_CORE
 #ifdef HAVE_MIGRAPHX_API_ONNX_OPTIONS_SET_EXTERNAL_DATA_PATH
         options.set_external_data_path(model_path_.parent_path().string());
@@ -1487,7 +1487,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       std::vector<std::int64_t> input_shapes;
 
       if (no_input_shape) {
-        LOGS_DEFAULT(INFO) << "Missing input shape setting input parameters again";
+        LOGS_DEFAULT(VERBOSE) << "Missing input shape setting input parameters again";
         for (auto& it : map_input_name_index) {
           auto& name = it.first;
           auto& index = it.second;
@@ -1499,7 +1499,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
           input_shape_match = false;
         }
       } else {
-        LOGS_DEFAULT(INFO) << "Assigning inputs, and parameters from compiled model";
+        LOGS_DEFAULT(VERBOSE) << "Assigning inputs, and parameters from compiled model";
         param_shapes = prog.get_parameter_shapes();
         auto prog_output_shapes = prog.get_output_shapes();
 
@@ -1586,7 +1586,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
       if (param_shapes.size() > 0) {
         for (auto&& name : param_shapes.names()) {
           if (map_input_name_index.count(name) > 0) {
-            LOGS_DEFAULT(INFO) << "Setting parameters for:" << name;
+            LOGS_DEFAULT(VERBOSE) << "Setting parameters for:" << name;
             auto input_tensor = ctx.GetInput(map_input_name_index[name]);
             auto tensor_info = input_tensor.GetTensorTypeAndShapeInfo();
             const auto tensor_shape = tensor_info.GetShape();
@@ -1600,7 +1600,7 @@ Status MIGraphXExecutionProvider::Compile(const std::vector<FusedNodeAndGraph>& 
               LOGS_DEFAULT(FATAL) << "MIGraphX: param type mismatch";
             }
 
-            LOGS_DEFAULT(INFO) << "Writing Raw tensor data ";
+            LOGS_DEFAULT(VERBOSE) << "Writing Raw tensor data ";
             m.add(name, migraphx::argument(param_shapes[name],
                                            const_cast<void*>(input_tensor.GetTensorRawData())));
           }


### PR DESCRIPTION
The number of logs is too extensive for production. They affect performance and pollute the log as well. We want to keep them, but we explicitly want to turn them on rather than have them printed out by default.