### PR TITLE
implement `cpplint` suggestions

### DIFF
--- a/onnxruntime/core/providers/migraphx/gpu_data_transfer.h
+++ b/onnxruntime/core/providers/migraphx/gpu_data_transfer.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "migraphx_inc.h"
 #include "core/framework/data_transfer.h"
+#include "core/providers/migraphx/migraphx_inc.h"
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/providers/migraphx/migraphx_allocator.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_allocator.cc
@@ -2,12 +2,11 @@
 // Licensed under the MIT License.
 
 #include "core/providers/shared_library/provider_api.h"
-#include "migraphx_call.h"
-#include "migraphx_allocator.h"
+#include "core/providers/migraphx/migraphx_call.h"
+#include "core/providers/migraphx/migraphx_allocator.h"
 #include "core/common/status.h"
 #include "core/framework/float16.h"
-#include "core/common/status.h"
-#include "gpu_data_transfer.h"
+#include "core/providers/migraphx/gpu_data_transfer.h"
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/providers/migraphx/migraphx_allocator.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_allocator.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
+#include <mutex>
 #include <unordered_set>
 #include "core/framework/allocator.h"
-#include <mutex>
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/providers/migraphx/migraphx_call.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_call.cc
@@ -1,21 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <cstdio>
+#include <string>
+
 #ifdef _WIN32
 #include <winsock.h>
 #else
 #include <unistd.h>
 #endif
 
-#include <string>
 #include "core/common/common.h"
 #include "core/common/status.h"
 #include "core/providers/shared_library/provider_api.h"
 #include "core/providers/migraphx/migraphx_call.h"
 
 namespace onnxruntime {
-
-using namespace common;
 
 template <typename ERRTYPE>
 const char* RocmErrString(ERRTYPE x) {
@@ -48,8 +48,8 @@ std::conditional_t<THRW, void, Status> RocmCall(
       (void)hipGetDevice(&currentHipDevice);
       (void)hipGetLastError();  // clear last HIP error
       static char str[1024];
-      snprintf(str, 1024, "%s failure %d: %s ; GPU=%d ; hostname=%s ; file=%s ; line=%d ; expr=%s; %s",
-               libName, (int)retCode, RocmErrString(retCode), currentHipDevice,
+      snprintf(str, sizeof(str), "%s failure %d: %s ; GPU=%d ; hostname=%s ; file=%s ; line=%d ; expr=%s; %s",
+               libName, static_cast<int>(retCode), RocmErrString(retCode), currentHipDevice,
                hostname.c_str(),
                file, line, exprString, msg);
       if constexpr (THRW) {

--- a/onnxruntime/core/providers/migraphx/migraphx_call.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_call.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "migraphx_inc.h"
+#include "core/providers/migraphx/migraphx_inc.h"
 #include "core/common/common.h"
 
 namespace onnxruntime {

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider.h
@@ -3,16 +3,19 @@
 
 #pragma once
 
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <mutex>
 #include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "core/framework/arena_extend_strategy.h"
 #include "core/framework/execution_provider.h"
-#include <mutex>
 #include "core/providers/migraphx/migraphx_execution_provider_info.h"
 #include "core/providers/migraphx/migraphx_call.h"
-
-#include <map>
-#include <unordered_map>
-#include <filesystem>
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_info.cc
@@ -1,14 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include <string>
+
 #include "core/providers/shared_library/provider_api.h"
 #include "core/providers/migraphx/migraphx_execution_provider_info.h"
 
 #include "core/common/make_string.h"
 #include "core/common/parse_string.h"
 #include "core/framework/provider_options_utils.h"
-#include "migraphx_inc.h"
-#include "migraphx_call.h"
+#include "core/providers/migraphx/migraphx_inc.h"
+#include "core/providers/migraphx/migraphx_call.h"
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_execution_provider_utils.h
@@ -3,14 +3,15 @@
 
 #pragma once
 
+#include <algorithm>
 #include <charconv>
-#include <fstream>
-#include <unordered_map>
-#include <string>
-#include <vector>
-#include <iostream>
 #include <filesystem>
+#include <fstream>
+#include <iostream>
 #include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
 #include "flatbuffers/idl.h"
 #include "core/providers/migraphx/ort_trt_int8_cal_table.fbs.h"
 #include "core/session/onnxruntime_cxx_api.h"

--- a/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_provider_factory.cc
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License
+
 #include <atomic>
+#include <memory>
 #include <string>
 
 #ifdef _WIN32
@@ -11,16 +13,14 @@
 
 #include "core/providers/shared_library/provider_api.h"
 #include "core/providers/migraphx/migraphx_provider_factory.h"
-#include "migraphx_execution_provider.h"
-#include "migraphx_execution_provider_info.h"
-#include "migraphx_provider_factory_creator.h"
-#include "migraphx_allocator.h"
-#include "gpu_data_transfer.h"
+#include "core/providers/migraphx/migraphx_execution_provider.h"
+#include "core/providers/migraphx/migraphx_execution_provider_info.h"
+#include "core/providers/migraphx/migraphx_provider_factory_creator.h"
+#include "core/providers/migraphx/migraphx_allocator.h"
+#include "core/providers/migraphx/gpu_data_transfer.h"
 #include "core/framework/provider_options.h"
 
 #include "core/session/onnxruntime_c_api.h"
-
-using namespace onnxruntime;
 
 namespace onnxruntime {
 

--- a/onnxruntime/core/providers/migraphx/migraphx_provider_factory.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_provider_factory.h
@@ -1,7 +1,11 @@
 // Copyright 2019 AMD AMDMIGraphX
 
+#pragma once
+
+#include <memory>
+
 #include "core/framework/ortdevice.h"
-#include "onnxruntime_c_api.h"
+#include "core/session/onnxruntime_c_api.h"
 
 namespace onnxruntime {
 class IAllocator;

--- a/onnxruntime/core/providers/migraphx/migraphx_stream_handle.cc
+++ b/onnxruntime/core/providers/migraphx/migraphx_stream_handle.cc
@@ -1,17 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <core/providers/rocm/rocm_resource.h>
-#include "migraphx_stream_handle.h"
+#include <memory>
+#include <utility>
+#include "core/providers/resource.h"
+#include "core/providers/migraphx/migraphx_stream_handle.h"
+
+#define MIGRAPHX_RESOURCE_VERSION 1
 
 namespace onnxruntime {
 
-struct MIGraphXNotification : public synchronize::Notification {
-  MIGraphXNotification(Stream& s) : Notification(s) {
+enum class MIGraphXResource {
+  hip_stream_t = rocm_resource_offset
+};
+
+struct MIGraphXNotification : synchronize::Notification {
+  explicit MIGraphXNotification(Stream& s) : Notification(s) {
     HIP_CALL_THROW(hipEventCreateWithFlags(&event_, hipEventDisableTiming));
   }
 
-  ~MIGraphXNotification() {
+  ~MIGraphXNotification() override {
     if (event_)
       HIP_CALL_THROW(hipEventDestroy(event_));
   }
@@ -21,18 +29,18 @@ struct MIGraphXNotification : public synchronize::Notification {
     HIP_CALL_THROW(hipEventRecord(event_, static_cast<hipStream_t>(stream_.GetHandle())));
   }
 
-  void wait_on_device(Stream& device_stream) {
+  void wait_on_device(const Stream& device_stream) const {
     ORT_ENFORCE(device_stream.GetDevice().Type() == OrtDevice::GPU, "Unexpected device:", device_stream.GetDevice().ToString());
     // launch a wait command to the migraphx stream
     HIP_CALL_THROW(hipStreamWaitEvent(static_cast<hipStream_t>(device_stream.GetHandle()), event_, 0));
-  };
+  }
 
-  void wait_on_host() {
+  void wait_on_host() const {
     // CUDA_CALL_THROW(cudaStreamSynchronize(stream_));
     HIP_CALL_THROW(hipEventSynchronize(event_));
   }
 
-  hipEvent_t event_;
+  hipEvent_t event_{};
 };
 
 MIGraphXStream::MIGraphXStream(hipStream_t stream,
@@ -40,15 +48,14 @@ MIGraphXStream::MIGraphXStream(hipStream_t stream,
                                AllocatorPtr cpu_allocator,
                                bool release_cpu_buffer_on_migraphx_stream)
     : Stream(stream, device),
-      cpu_allocator_(cpu_allocator),
+      cpu_allocator_(std::move(cpu_allocator)),
       release_cpu_buffer_on_migraphx_stream_(release_cpu_buffer_on_migraphx_stream) {
 }
 
 MIGraphXStream::~MIGraphXStream() {
-  ORT_IGNORE_RETURN_VALUE(CleanUpOnRunEnd());
+  ORT_IGNORE_RETURN_VALUE(MIGraphXStream::CleanUpOnRunEnd());
   if (own_stream_) {
-    auto* handle = GetHandle();
-    if (handle)
+    if (auto* handle = GetHandle())
       HIP_CALL_THROW(hipStreamDestroy(static_cast<hipStream_t>(handle)));
   }
 }
@@ -86,12 +93,12 @@ struct CpuBuffersInfo {
   std::unique_ptr<void*[]> buffers;
   // CPU buffer buffers[i].
   // Number of buffer points in "buffers".
-  size_t n_buffers;
+  size_t n_buffers{};
 };
 
 static void ReleaseCpuBufferCallback(void* raw_info) {
   std::unique_ptr<CpuBuffersInfo> info = std::make_unique<CpuBuffersInfo>();
-  info.reset(reinterpret_cast<CpuBuffersInfo*>(raw_info));
+  info.reset(static_cast<CpuBuffersInfo*>(raw_info));
   for (size_t i = 0; i < info->n_buffers; ++i) {
     info->allocator->Free(info->buffers[i]);
   }
@@ -123,29 +130,28 @@ Status MIGraphXStream::CleanUpOnRunEnd() {
 }
 
 void* MIGraphXStream::GetResource(int version, int id) const {
-  ORT_ENFORCE(version <= ORT_ROCM_RESOURCE_VERSION, "resource version unsupported!");
-  void* resource{};
+  ORT_ENFORCE(version <= MIGRAPHX_RESOURCE_VERSION, "resource version unsupported!");
   switch (id) {
-    case RocmResource::hip_stream_t:
-      return reinterpret_cast<void*>(GetHandle());
+    case MIGraphXResource::hip_stream_t:
+      return GetHandle();
     default:
       break;
   }
-  return resource;
+  return nullptr;
 }
 
 // CPU Stream command handles
-void WaitMIGraphXNotificationOnDevice(Stream& stream, synchronize::Notification& notification) {
-  static_cast<MIGraphXNotification*>(&notification)->wait_on_device(stream);
+void WaitMIGraphXNotificationOnDevice(const Stream& stream, synchronize::Notification& notification) {
+  dynamic_cast<MIGraphXNotification*>(&notification)->wait_on_device(stream);
 }
 
 void WaitMIGraphXNotificationOnHost(Stream& /*stream*/, synchronize::Notification& notification) {
-  static_cast<MIGraphXNotification*>(&notification)->wait_on_host();
+  dynamic_cast<MIGraphXNotification*>(&notification)->wait_on_host();
 }
 
 void RegisterMIGraphXStreamHandles(IStreamCommandHandleRegistry& stream_handle_registry,
                                    const OrtDevice::DeviceType device_type,
-                                   AllocatorPtr cpu_allocator,
+                                   const AllocatorPtr& cpu_allocator,
                                    bool release_cpu_buffer_on_migraphx_stream,
                                    hipStream_t external_stream,
                                    bool use_existing_stream) {
@@ -153,19 +159,20 @@ void RegisterMIGraphXStreamHandles(IStreamCommandHandleRegistry& stream_handle_r
   stream_handle_registry.RegisterWaitFn(device_type, device_type, WaitMIGraphXNotificationOnDevice);
   // wait migraphx notification on cpu ep
   stream_handle_registry.RegisterWaitFn(device_type, OrtDevice::CPU, WaitMIGraphXNotificationOnHost);
-  if (!use_existing_stream)
+  if (!use_existing_stream) {
     stream_handle_registry.RegisterCreateStreamFn(device_type, [cpu_allocator, release_cpu_buffer_on_migraphx_stream](const OrtDevice& device) {
       HIP_CALL_THROW(hipSetDevice(device.Id()));
       hipStream_t stream = nullptr;
       HIP_CALL_THROW(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
       return std::make_unique<MIGraphXStream>(stream, device, cpu_allocator, release_cpu_buffer_on_migraphx_stream);
     });
-  else
+  } else {
     stream_handle_registry.RegisterCreateStreamFn(device_type, [cpu_allocator,
                                                                 release_cpu_buffer_on_migraphx_stream,
                                                                 external_stream](const OrtDevice& device) {
       return std::make_unique<MIGraphXStream>(external_stream, device, cpu_allocator, release_cpu_buffer_on_migraphx_stream);
     });
+  }
 }
 
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/migraphx/migraphx_stream_handle.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_stream_handle.h
@@ -2,12 +2,16 @@
 // Licensed under the MIT License.
 
 #pragma once
+
+#include <memory>
+#include <vector>
+
 #include "core/framework/stream_handles.h"
-#include "migraphx_inc.h"
-#include "migraphx_call.h"
+#include "core/providers/migraphx/migraphx_inc.h"
+#include "core/providers/migraphx/migraphx_call.h"
 
 namespace onnxruntime {
-void WaitMIGraphXNotificationOnDevice(Stream& stream, synchronize::Notification& notification);
+void WaitMIGraphXNotificationOnDevice(const Stream& stream, synchronize::Notification& notification);
 
 struct MIGraphXStream : Stream {
   MIGraphXStream(hipStream_t stream,
@@ -39,7 +43,7 @@ struct MIGraphXStream : Stream {
 
 void RegisterMIGraphXStreamHandles(IStreamCommandHandleRegistry& stream_handle_registry,
                                    const OrtDevice::DeviceType device_type,
-                                   AllocatorPtr cpu_allocator,
+                                   const AllocatorPtr& cpu_allocator,
                                    bool release_cpu_buffer_on_migraphx_stream,
                                    hipStream_t external_stream,
                                    bool use_existing_stream);


### PR DESCRIPTION
This is not the original PR from wml-main, but I ran cpplint on each `.cc`/`.h` file of MIGraphX EP and implemented the following suggestions.

* "header_file" already included at ...
* include the directory when naming header files
* found C++ header after other headers
* found C header after other headers
* do not use namespace using-directives
* single parameter constructor should be marked explicit
* add `#include <header files>` for `<feature>`
* missing guard definition or `#pragma once`
* if/else bodies with multiple statements require braces
* use operator `||` instead of `or`
* use operator `&&` instead of `and`
* use operator `^` instead of `xor`
* use `sizeof(str)` instead of 1024 as second arg to snprintf
