### PR TITLE
The C# interface for MIGraphX execution provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # build, distribute, and bins (+ python proto bindings)
+build.*/
 build
 build_*/
 .build_debug/*

--- a/csharp/OnnxRuntime.CSharp.proj
+++ b/csharp/OnnxRuntime.CSharp.proj
@@ -163,6 +163,11 @@ CMake creates a target to this project
              Targets ="CreateNativePackage" />
   </Target>
 
+  <Target Name="CreateAllMIGraphXPackages" AfterTargets="CreatePackage" Condition="'$(OrtPackageId)' == 'Microsoft.ML.OnnxRuntime.MIGraphX'">
+    <MSBuild Projects ="$(MSBuildProjectFullPath)"
+             Properties="NuSpecName=NativeMIGraphXWinNuget.nuspec;OrtPackageId=Microsoft.ML.OnnxRuntime.MIGraphX.Windows"
+             Targets ="CreateNativePackage" />
+  </Target>
   <ItemGroup>
     <LicenseFile Include="$(OnnxRuntimeSourceDirectory)\LICENSE"/>
   </ItemGroup>

--- a/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/NativeMethods.shared.cs
@@ -336,6 +336,13 @@ namespace Microsoft.ML.OnnxRuntime
         public IntPtr GetModelEditorApi;
         public IntPtr CreateTensorWithDataAndDeleterAsOrtValue;
         public IntPtr SessionOptionsSetLoadCancellationFlag;
+ 
+        public IntPtr CreateMIGraphXProviderOptions;
+        public IntPtr UpdateMIGraphXProviderOptions;
+        public IntPtr GetMIGraphXProviderOptionsAsString;
+        public IntPtr ReleaseMIGraphXProviderOptions;
+        public IntPtr UpdateMIGraphXProviderOptionsWithValue;
+        public IntPtr GetMIGraphXProviderOptionsByName;
     }
 
     internal static class NativeMethods
@@ -573,6 +580,18 @@ namespace Microsoft.ML.OnnxRuntime
             OrtUpdateROCMProviderOptions = (DOrtUpdateROCMProviderOptions)Marshal.GetDelegateForFunctionPointer(api_.UpdateROCMProviderOptions, typeof(DOrtUpdateROCMProviderOptions));
             OrtGetROCMProviderOptionsAsString = (DOrtGetROCMProviderOptionsAsString)Marshal.GetDelegateForFunctionPointer(api_.GetROCMProviderOptionsAsString, typeof(DOrtGetROCMProviderOptionsAsString));
             OrtReleaseROCMProviderOptions = (DOrtReleaseROCMProviderOptions)Marshal.GetDelegateForFunctionPointer(api_.ReleaseROCMProviderOptions, typeof(DOrtReleaseROCMProviderOptions));
+            SessionOptionsAppendExecutionProvider_MIGraphX = (DSessionOptionsAppendExecutionProvider_MIGraphX)Marshal.GetDelegateForFunctionPointer(
+                api_.SessionOptionsAppendExecutionProvider_MIGraphX, typeof(DSessionOptionsAppendExecutionProvider_MIGraphX));
+            OrtCreateMIGraphXProviderOptions = (DOrtCreateMIGraphXProviderOptions)Marshal.GetDelegateForFunctionPointer(api_.CreateMIGraphXProviderOptions, typeof(DOrtCreateMIGraphXProviderOptions));
+            OrtUpdateMIGraphXProviderOptions = (DOrtUpdateMIGraphXProviderOptions)Marshal.GetDelegateForFunctionPointer(api_.UpdateMIGraphXProviderOptions, typeof(DOrtUpdateMIGraphXProviderOptions));
+            OrtGetMIGraphXProviderOptionsAsString = (DOrtGetMIGraphXProviderOptionsAsString)Marshal.GetDelegateForFunctionPointer(api_.GetMIGraphXProviderOptionsAsString, typeof(DOrtGetMIGraphXProviderOptionsAsString));
+            OrtReleaseMIGraphXProviderOptions = (DOrtReleaseMIGraphXProviderOptions)Marshal.GetDelegateForFunctionPointer(api_.ReleaseMIGraphXProviderOptions, typeof(DOrtReleaseMIGraphXProviderOptions));
+            OrtUpdateMIGraphXProviderOptionsWithValue =
+                (DOrtUpdateMIGraphXProviderOptionsWithValue)Marshal.GetDelegateForFunctionPointer(
+                    api_.UpdateMIGraphXProviderOptionsWithValue, typeof(DOrtUpdateMIGraphXProviderOptionsWithValue));
+            OrtGetMIGraphXProviderOptionsByName =
+                (DOrtGetMIGraphXProviderOptionsByName)Marshal.GetDelegateForFunctionPointer(
+                    api_.GetMIGraphXProviderOptionsByName, typeof(DOrtGetMIGraphXProviderOptionsByName));
             OrtCreateAndRegisterAllocatorV2 = (DCreateAndRegisterAllocatorV2)Marshal.GetDelegateForFunctionPointer(api_.CreateAndRegisterAllocatorV2, typeof(DCreateAndRegisterAllocatorV2));
             OrtRunAsync = (DOrtRunAsync)Marshal.GetDelegateForFunctionPointer(api_.RunAsync, typeof(DOrtRunAsync));
             CreateLoraAdapter = (DCreateLoraAdapter)Marshal.GetDelegateForFunctionPointer(api_.CreateLoraAdapter,
@@ -797,6 +816,80 @@ namespace Microsoft.ML.OnnxRuntime
         public delegate void DOrtReleaseROCMProviderOptions(IntPtr /*(OrtROCMProviderOptions*)*/ rocmProviderOptionsInstance);
         public static DOrtReleaseROCMProviderOptions OrtReleaseROCMProviderOptions;
 
+#endregion
+
+#region Provider Options API
+        /// <summary>
+        /// Creates native OrtMIGraphXProviderOptions instance
+        /// </summary>
+        /// <param name="trtProviderOptionsInstance">(output) native instance of OrtMIGraphXProviderOptions</param>
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr /* OrtStatus* */ DOrtCreateMIGraphXProviderOptions(
+            out IntPtr /*(OrtMIGraphXProviderOptions**)*/ migraphxProviderOptionsInstance);
+        public static DOrtCreateMIGraphXProviderOptions OrtCreateMIGraphXProviderOptions;
+
+        /// <summary>
+        /// Updates native OrtMIGraphXProviderOptions instance using given key/value pairs
+        /// </summary>
+        /// <param name="migraphxProviderOptionsInstance">native instance of OrtMIGraphXProviderOptions</param>
+        /// <param name="providerOptionsKeys">configuration keys of OrtMIGraphXProviderOptions</param>
+        /// <param name="providerOptionsValues">configuration values of OrtMIGraphXProviderOptions</param>
+        /// <param name="numKeys">number of configuration keys</param>
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr /* OrtStatus* */ DOrtUpdateMIGraphXProviderOptions(
+            IntPtr /*(OrtMIGraphXProviderOptions*)*/ migraphxProviderOptionsInstance,
+            IntPtr[] /*(const char* const *)*/ providerOptionsKeys,
+            IntPtr[] /*(const char* const *)*/ providerOptionsValues,
+            UIntPtr /*(size_t)*/ numKeys);
+        public static DOrtUpdateMIGraphXProviderOptions OrtUpdateMIGraphXProviderOptions;
+
+        /// <summary>
+        /// Get native OrtMIGraphXProviderOptions in serialized string
+        /// </summary>
+        /// <param name="allocator">instance of OrtAllocator</param>
+        /// <param name="ptr">is a UTF-8 null terminated string allocated using 'allocator'</param>
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr /* OrtStatus* */ DOrtGetMIGraphXProviderOptionsAsString(
+            IntPtr /*(OrtMIGraphXProviderOptions**)*/ migraphxProviderOptionsInstance,
+            IntPtr /*(OrtAllocator*)*/ allocator,
+            out IntPtr /*(char**)*/ ptr);
+        public static DOrtGetMIGraphXProviderOptionsAsString OrtGetMIGraphXProviderOptionsAsString;
+
+        /// <summary>
+        /// Releases native OrtMIGraphXProviderOptions instance
+        /// </summary>
+        /// <param name="migraphxProviderOptionsInstance">native instance of OrtMIGraphXProviderOptions to be released</param>
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate void DOrtReleaseMIGraphXProviderOptions(IntPtr /*(OrtMIGraphXProviderOptions*)*/ migraphxProviderOptionsInstance);
+        public static DOrtReleaseMIGraphXProviderOptions OrtReleaseMIGraphXProviderOptions;
+
+        /// <summary>
+        /// Update native OrtMIGraphXProviderOptions with value
+        /// </summary>
+        /// <param name="migraphxProviderOptionsInstance">native instance of OrtMIGraphXProviderOptions to be released</param>
+        /// <param name="providerOptionsKey">configuration key of OrtMIGraphXProviderOptions</param>
+        /// <param name="providerOptionsValue">configuration value of OrtMIGraphXProviderOptions</param>
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr DOrtUpdateMIGraphXProviderOptionsWithValue(
+            IntPtr /*(OrtMIGraphXProviderOptions**)*/ migraphxProviderOptionsInstance,
+            IntPtr /*(char*)*/ providerOptionsKey,
+            IntPtr /*(char*)*/ providerOptionsValue);
+        public static DOrtUpdateMIGraphXProviderOptionsWithValue OrtUpdateMIGraphXProviderOptionsWithValue;
+
+        /// <summary>
+        /// Get native OrtMIGraphXProviderOptions value by name
+        /// </summary>
+        /// <param name="migraphxProviderOptionsInstance">native instance of OrtMIGraphXProviderOptions to be released</param>
+        /// <param name="providerOptionsKey">configuration key of OrtMIGraphXProviderOptions</param>
+        /// <param name="providerOptionsValue">configuration value of OrtMIGraphXProviderOptions to return</param>
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr DOrtGetMIGraphXProviderOptionsByName(
+            IntPtr /*(OrtMIGraphXProviderOptions**)*/ migraphxProviderOptionsInstance,
+            IntPtr /*(char*)*/ providerOptionsKey,
+            out IntPtr /*(char**)*/ providerOptionsValue);
+        public static DOrtGetMIGraphXProviderOptionsByName OrtGetMIGraphXProviderOptionsByName;
+
+        
 #endregion
 
 #region Status API
@@ -1160,6 +1253,9 @@ namespace Microsoft.ML.OnnxRuntime
 
         [DllImport(NativeLib.DllName, CharSet = CharSet.Ansi)]
         public static extern IntPtr /*(OrtStatus*)*/ OrtSessionOptionsAppendExecutionProvider_MIGraphX(IntPtr /*(OrtSessionOptions*)*/ options, int device_id);
+
+        [DllImport(NativeLib.DllName, CharSet = CharSet.Ansi)]
+        public static extern IntPtr /*(OrtStatus*)*/ OrtSessionOptionsAppendExecutionProvider_MIGraphX(IntPtr /*(OrtSessionOptions*)*/ options, int use_arena, int device_id);
 #endif
         /// <summary>
         /// Append a TensorRT EP instance (configured based on given provider options) to the native OrtSessionOptions instance
@@ -1220,6 +1316,18 @@ namespace Microsoft.ML.OnnxRuntime
             IntPtr /*(const OrtROCMProviderOptions*)*/ rocmProviderOptions);
 
         public static DSessionOptionsAppendExecutionProvider_ROCM SessionOptionsAppendExecutionProvider_ROCM;
+
+        /// <summary>
+        /// Append a MIGraphX EP instance (configured based on given provider options) to the native OrtSessionOptions instance
+        /// </summary>
+        /// <param name="options">Native OrtSessionOptions instance</param>
+        /// <param name="migraphxProviderOptions">Native OrtMIGraphXProviderOptions instance</param>
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        public delegate IntPtr /*(OrtStatus*)*/ DSessionOptionsAppendExecutionProvider_MIGraphX(
+            IntPtr /*(OrtSessionOptions*)*/ options,
+            IntPtr /*(const OrtMIGraphXProviderOptions*)*/ migraphxProviderOptions);
+
+        public static DSessionOptionsAppendExecutionProvider_MIGraphX SessionOptionsAppendExecutionProvider_MIGraphX;
 
         /// <summary>
         /// Free Dimension override (by denotation)

--- a/csharp/src/Microsoft.ML.OnnxRuntime/ProviderOptions.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/ProviderOptions.shared.cs
@@ -291,6 +291,142 @@ namespace Microsoft.ML.OnnxRuntime
     }
 
 
+/// <summary>
+    /// Holds the options for configuring an MIGraphX Execution Provider instance
+    /// </summary>
+    public class OrtMIGraphXProviderOptions : SafeHandle
+    {
+        internal IntPtr Handle
+        {
+            get
+            {
+                return handle;
+            }
+        }
+
+        public int DeviceId
+        {
+            get { return _deviceId; }
+            set
+            {
+                UpdateProviderOptionWithValue(_deviceIdPtr, value.ToString());
+                _deviceId = value;
+            }
+        }
+        private IntPtr _deviceIdPtr = Marshal.StringToHGlobalAnsi("device_id");
+        private int _deviceId = 0;
+
+        public string ModelCacheDir
+        {
+            get { return _modelCacheDir; }
+            set
+            {
+                UpdateProviderOptionWithValue(_modelCacheDirPtr, value);
+                _modelCacheDir = value;
+            }
+        }
+        
+        private IntPtr _modelCacheDirPtr = Marshal.StringToHGlobalAnsi("migraphx_model_cache_dir");
+        private string _modelCacheDir = "";
+        
+        #region Constructor
+
+        /// <summary>
+        /// Constructs an empty OrtMIGraphXProviderOptions instance
+        /// </summary>
+        public OrtMIGraphXProviderOptions() : base(IntPtr.Zero, true)
+        {
+            NativeApiStatus.VerifySuccess(NativeMethods.OrtCreateMIGraphXProviderOptions(out handle));
+        }
+
+        #endregion
+
+        #region Finalizer
+
+        ~OrtMIGraphXProviderOptions()
+        {
+            Marshal.FreeHGlobal(_deviceIdPtr);
+            Marshal.FreeHGlobal(_modelCacheDirPtr);
+        }
+        
+        #endregion
+        
+        #region Public Methods
+
+        /// <summary>
+        /// Get MIGraphX EP provider options
+        /// </summary>
+        /// <returns> return C# UTF-16 encoded string </returns>
+        public string GetOptions()
+        {
+            var allocator = OrtAllocator.DefaultInstance;
+            // Process provider options string
+            NativeApiStatus.VerifySuccess(NativeMethods.OrtGetMIGraphXProviderOptionsAsString(handle,
+                allocator.Pointer, out IntPtr providerOptions));
+            return NativeOnnxValueHelper.StringFromNativeUtf8(providerOptions, allocator);
+        }
+
+        /// <summary>
+        /// Updates the configuration knobs of OrtMIGraphXProviderOptions that will eventually be used to configure a MIGraphX EP
+        /// </summary>
+        /// <param name="keys">Array of keys to set that correspond with values.</param>
+        /// <param name="values">Array of values to set that correspond with keys.</param>
+        /// <param name="count">The number of key/value pairs in the arrays.</param>
+        private static IntPtr UpdateMIGraphXProviderOptions(IntPtr handle, IntPtr[] keys, IntPtr[] values, UIntPtr count)
+        {
+            return NativeMethods.OrtUpdateMIGraphXProviderOptions(handle, keys, values, count);
+        }
+
+        /// <summary>
+        /// Updates the configuration knobs of OrtMIGraphXProviderOptions that will eventually be used to configure a MIGraphX EP
+        /// </summary>
+        /// <param name="providerOptions">key/value pairs used to configure a MIGraphX Execution Provider</param>
+        public void UpdateOptions(Dictionary<string, string> providerOptions)
+        {
+            ProviderOptionsUpdater.Update(providerOptions, handle, UpdateMIGraphXProviderOptions);
+        }
+        
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>
+        /// Overrides SafeHandle.IsInvalid
+        /// </summary>
+        /// <value>returns true if handle is equal to Zero</value>
+        public override bool IsInvalid { get { return handle == IntPtr.Zero; } }
+
+        #endregion
+
+        #region Private Methods
+
+        private void UpdateProviderOptionWithValue(IntPtr key, string value)
+        {
+            IntPtr valuePtr = Marshal.StringToHGlobalAnsi(value);
+            var nativeStatus = NativeMethods.OrtUpdateMIGraphXProviderOptionsWithValue(handle, key, valuePtr);
+            Marshal.FreeHGlobal(valuePtr);
+            NativeApiStatus.VerifySuccess(nativeStatus);
+        }
+
+        #endregion
+
+        #region SafeHandle
+        /// <summary>
+        /// Overrides SafeHandle.ReleaseHandle() to properly dispose of
+        /// the native instance of OrtMIGraphXProviderOptions
+        /// </summary>
+        /// <returns>always returns true</returns>
+        protected override bool ReleaseHandle()
+        {
+            NativeMethods.OrtReleaseMIGraphXProviderOptions(handle);
+            handle = IntPtr.Zero;
+            return true;
+        }
+
+        #endregion
+    }
+
+
     /// <summary>
     /// This helper class contains methods to handle values of provider options
     /// </summary>

--- a/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
+++ b/csharp/src/Microsoft.ML.OnnxRuntime/SessionOptions.shared.cs
@@ -42,6 +42,9 @@ namespace Microsoft.ML.OnnxRuntime
         private static string[] cudaDelayLoadedLibs = { };
         private static string[] trtDelayLoadedLibs = { };
 
+        // Delay-loaded MIGraphX DLLs. Currently, delayload is disabled. See cmake/CMakeLists.txt for more information.
+        private static string[] migxDelayLoadedLibs = { };
+
         #region Constructor and Factory methods
 
         /// <summary>
@@ -181,6 +184,28 @@ namespace Microsoft.ML.OnnxRuntime
             try
             {
                 options.AppendExecutionProvider_ROCm(rocmProviderOptions);
+                return options;
+            }
+            catch (Exception)
+            {
+                options.Dispose();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// A helper method to construct a SessionOptions object for MIGraaphX execution provider.
+        /// Use only if MIGraphX is installed and you have the onnxruntime package specific to this Execution Provider.
+        /// </summary>
+        /// <param name="migxProviderOptions">MIGraphX EP provider options</param>
+        /// <returns>A SessionsOptions() object configured for execution on provider options</returns>
+        public static SessionOptions MakeSessionOptionWithMIGraphXProvider(OrtMIGraphXProviderOptions migxProviderOptions)
+        {
+            CheckMIGraphXExecutionProviderDLLs();
+            SessionOptions options = new SessionOptions();
+            try
+            {
+                options.AppendExecutionProvider_MIGraphX(migxProviderOptions);
                 return options;
             }
             catch (Exception)
@@ -331,9 +356,22 @@ namespace Microsoft.ML.OnnxRuntime
         public void AppendExecutionProvider_MIGraphX(int deviceId = 0)
         {
 #if __MOBILE__
-            throw new NotSupportedException($"The MIGraphX Execution Provider is not supported in this build");
+            throw new NotSupportedException("The MIGraphX Execution Provider is not supported in this build");
 #else
             NativeApiStatus.VerifySuccess(NativeMethods.OrtSessionOptionsAppendExecutionProvider_MIGraphX(handle, deviceId));
+#endif
+        }
+
+        /// <summary>
+        /// Use only if you have the onnxruntime package specific to this Execution Provider.
+        /// </summary>
+        /// <param name="deviceId">device identification</param>
+        public void AppendExecutionProvider_MIGraphX(OrtMIGraphXProviderOptions migraphxProviderOptions)
+        {
+#if __MOBILE__
+            throw new NotSupportedException($"The AMD Nitris Execution Provider is not supported in this build");
+#else
+            NativeApiStatus.VerifySuccess(NativeMethods.SessionOptionsAppendExecutionProvider_MIGraphX(handle, migraphxProviderOptions.Handle));
 #endif
         }
 
@@ -885,6 +923,27 @@ namespace Microsoft.ML.OnnxRuntime
             return true;
         }
 
+        private static bool CheckMIGraphXExecutionProviderDLLs()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                foreach (var dll in migxDelayLoadedLibs)
+                {
+                    IntPtr handle = LoadLibrary(dll);
+                    if (handle != IntPtr.Zero)
+                        continue;
+                    var sysdir = new StringBuilder(String.Empty, 2048);
+                    GetSystemDirectory(sysdir, (uint)sysdir.Capacity);
+                    throw new OnnxRuntimeException(
+                        ErrorCode.NoSuchFile,
+                        $"kernel32.LoadLibrary():'{dll}' not found. MIGraphX are required for GPU execution. " +
+                        $". Verify it is available in the system directory={sysdir}. Else copy it to the output folder."
+                    );
+                }
+            }
+            return true;
+        }
+        
         #endregion
 
         #region SafeHandle

--- a/include/onnxruntime/core/session/onnxruntime_c_api.h
+++ b/include/onnxruntime/core/session/onnxruntime_c_api.h
@@ -5265,6 +5265,88 @@ struct OrtApi {
    * \since Version 1.22.
    */
   const OrtEpApi*(ORT_API_CALL* GetEpApi)();
+
+  /// @}
+  /// \name OrtMIGraphXProviderOptions
+  /// @{
+
+  /** \brief Create an OrtMIGraphXProviderOptions
+   *
+   * \param[out] out Newly created ::OrtMIGraphXProviderOptions. Must be released with OrtApi::ReleaseMIGraphXProviderOptions
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.xx.
+   */
+  ORT_API2_STATUS(CreateMIGraphXProviderOptions, _Outptr_ OrtMIGraphXProviderOptions** out);
+
+  /** \brief Set options in a MIGraphX Execution Provider.
+   *
+   * For example, key="device_id" and value="0"
+   *
+   * \param[in] migraphx_options
+   * \param[in] provider_options_keys Array of UTF-8 null-terminated string for provider options keys
+   * \param[in] provider_options_values Array of UTF-8 null-terminated string for provider options values
+   * \param[in] num_keys Number of elements in the `provider_option_keys` and `provider_options_values` arrays
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.xx.
+   */
+  ORT_API2_STATUS(UpdateMIGraphXProviderOptions, _Inout_ OrtMIGraphXProviderOptions* migraphx_options,
+                  _In_reads_(num_keys) const char* const* provider_options_keys,
+                  _In_reads_(num_keys) const char* const* provider_options_values,
+                  _In_ size_t num_keys);
+
+  /**
+   * Get serialized MIGraphX provider options string.
+   *
+   * For example, "device_id=0;;......"
+   *
+   * \param migraphx_options - OrtMIGraphXProviderOptions instance
+   * \param allocator - a ptr to an instance of OrtAllocator obtained with CreateAllocator() or GetAllocatorWithDefaultOptions()
+   *                      the specified allocator will be used to allocate continuous buffers for output strings and lengths.
+   * \param ptr - is a UTF-8 null terminated string allocated using 'allocator'. The caller is responsible for using the same allocator to free it.
+   *
+   * \snippet{doc} snippets.dox OrtStatus Return Value
+   *
+   * \since Version 1.xx.
+   */
+  ORT_API2_STATUS(GetMIGraphXProviderOptionsAsString, _In_ const OrtMIGraphXProviderOptions* migraphx_options, _Inout_ OrtAllocator* allocator, _Outptr_ char** ptr);
+
+  /** \brief Release an ::OrtMIGraphXProviderOptions
+   *
+   * \note This is an exception in the naming convention of other Release* functions, as the name of the method does not have the V2 suffix, but the type does
+   *
+   * \since Version 1.xx.
+   */
+  void(ORT_API_CALL* ReleaseMIGraphXProviderOptions)(_Frees_ptr_opt_ OrtMIGraphXProviderOptions* input);
+
+  /**
+   * Update MIGraphX EP provider option where its data type is pointer, for example 'user_compute_stream'.
+   * If the data type of the provider option can be represented by string please use UpdateMIGraphXProviderOptions.
+   *
+   * Note: It's caller's responsibility to properly manage the lifetime of the instance pointed by this pointer.
+   *
+   * \param migraphx_options - OrtMIGraphXProviderOptions instance
+   * \param key - Name of the provider option
+   * \param value - A pointer to the instance that will be assigned to this provider option
+   *
+   * \since Version 1.xx.
+   */
+  ORT_API2_STATUS(UpdateMIGraphXProviderOptionsWithValue, _Inout_ OrtMIGraphXProviderOptions* migraphx_options, _In_ const char* key, _In_ void* value);
+
+  /**
+   * Get MIGraphX EP provider option where its data type is pointer.
+   * If the data type of the provider option can be represented by string please use GetMIGraphXProviderOptionsAsString.
+   *
+   * \param migraphx_options - OrtMIGraphXProviderOptions instance
+   * \param key - Name of the provider option
+   * \param ptr - A pointer to the instance that is kept by the provider option
+   *
+   * \since Version 1.xx.
+   */
+  ORT_API2_STATUS(GetMIGraphXProviderOptionsByName, _In_ const OrtMIGraphXProviderOptions* migraphx_options, _In_ const char* key, _Outptr_ void** ptr);
 };
 
 /*

--- a/onnxruntime/core/providers/migraphx/migraphx_provider_factory_creator.h
+++ b/onnxruntime/core/providers/migraphx/migraphx_provider_factory_creator.h
@@ -3,9 +3,8 @@
 
 #pragma once
 
-#include <memory>
-
 #include "core/providers/providers.h"
+#include "core/framework/provider_options.h"
 
 struct OrtMIGraphXProviderOptions;
 
@@ -14,5 +13,6 @@ namespace onnxruntime {
 struct MIGraphXProviderFactoryCreator {
   static std::shared_ptr<IExecutionProviderFactory> Create(int device_id);
   static std::shared_ptr<IExecutionProviderFactory> Create(const OrtMIGraphXProviderOptions* options);
+  static std::shared_ptr<IExecutionProviderFactory> Create(const ProviderOptions&);
 };
 }  // namespace onnxruntime

--- a/onnxruntime/core/session/onnxruntime_c_api.cc
+++ b/onnxruntime/core/session/onnxruntime_c_api.cc
@@ -3029,6 +3029,12 @@ static constexpr OrtApi ort_api_1_to_22 = {
 
     &OrtApis::GetEpApi,
     // End of Version 22 - DO NOT MODIFY ABOVE (see above text for more information)
+    &OrtApis::CreateMIGraphXProviderOptions,
+    &OrtApis::UpdateMIGraphXProviderOptions,
+    &OrtApis::GetMIGraphXProviderOptionsAsString,
+    &OrtApis::ReleaseMIGraphXProviderOptions,
+    &OrtApis::UpdateMIGraphXProviderOptionsWithValue,
+    &OrtApis::GetMIGraphXProviderOptionsByName
 };
 
 // OrtApiBase can never change as there is no way to know what version of OrtApiBase is returned by OrtGetApiBase.

--- a/onnxruntime/core/session/ort_apis.h
+++ b/onnxruntime/core/session/ort_apis.h
@@ -597,4 +597,15 @@ ORT_API(const OrtKeyValuePairs*, EpDevice_EpOptions, _In_ const OrtEpDevice* ep_
 ORT_API(const OrtHardwareDevice*, EpDevice_Device, _In_ const OrtEpDevice* ep_device);
 
 ORT_API(const OrtEpApi*, GetEpApi);
+ORT_API_STATUS_IMPL(CreateMIGraphXProviderOptions, _Outptr_ OrtMIGraphXProviderOptions** out);
+ORT_API_STATUS_IMPL(UpdateMIGraphXProviderOptions, _Inout_ OrtMIGraphXProviderOptions* migraphx_options,
+                    _In_reads_(num_keys) const char* const* provider_options_keys,
+                    _In_reads_(num_keys) const char* const* provider_options_values,
+                    size_t num_keys);
+ORT_API_STATUS_IMPL(GetMIGraphXProviderOptionsAsString, _In_ const OrtMIGraphXProviderOptions* migraphx_options, _Inout_ OrtAllocator* allocator, _Outptr_ char** ptr);
+ORT_API(void, ReleaseMIGraphXProviderOptions, _Frees_ptr_opt_ OrtMIGraphXProviderOptions*);
+
+ORT_API_STATUS_IMPL(UpdateMIGraphXProviderOptionsWithValue, _Inout_ OrtMIGraphXProviderOptions* migraphx_options, _In_ const char* key, _In_ void* value);
+ORT_API_STATUS_IMPL(GetMIGraphXProviderOptionsByName, _In_ const OrtMIGraphXProviderOptions* migraphx_options, _In_ const char* key, _Outptr_ void** ptr);
+
 }  // namespace OrtApis

--- a/onnxruntime/core/session/provider_bridge_ort.cc
+++ b/onnxruntime/core/session/provider_bridge_ort.cc
@@ -6,6 +6,7 @@
 
 #include <optional>
 #include <utility>
+#include <charconv>
 
 #include "core/common/inlined_containers.h"
 #include "core/common/path_string.h"
@@ -114,6 +115,7 @@ using EtwRegistrationManager_EtwInternalCallback = EtwRegistrationManager::EtwIn
 #include "core/providers/rocm/rocm_provider_factory.h"
 #include "core/providers/dnnl/dnnl_provider_factory.h"
 #include "core/providers/migraphx/migraphx_provider_factory.h"
+#include "core/providers/migraphx/migraphx_execution_provider_info.h"
 #include "core/providers/openvino/openvino_provider_factory.h"
 #include "core/providers/tensorrt/tensorrt_provider_factory.h"
 #include "core/providers/tensorrt/tensorrt_provider_options.h"
@@ -2065,6 +2067,12 @@ std::shared_ptr<IExecutionProviderFactory> NvProviderFactoryCreator::Create(
   return nullptr;
 }
 
+std::shared_ptr<IExecutionProviderFactory> MIGraphXProviderFactoryCreator::Create(const ProviderOptions& provider_options) {
+  OrtMIGraphXProviderOptions migraphx_options;
+  s_library_migraphx.Get().UpdateProviderOptions(&migraphx_options, provider_options);
+  return s_library_migraphx.Get().CreateExecutionProviderFactory(&migraphx_options);
+}
+
 std::shared_ptr<IExecutionProviderFactory> MIGraphXProviderFactoryCreator::Create(const OrtMIGraphXProviderOptions* provider_options) {
   return s_library_migraphx.Get().CreateExecutionProviderFactory(provider_options);
 }
@@ -2655,7 +2663,8 @@ ORT_API_STATUS_IMPL(OrtApis::UpdateTensorRTProviderOptions,
     defined(USE_CUDA) || defined(USE_CUDA_PROVIDER_INTERFACE) ||         \
     defined(USE_CANN) ||                                                 \
     defined(USE_DNNL) ||                                                 \
-    defined(USE_ROCM)
+    defined(USE_ROCM) ||                                                 \
+    defined(USE_MIGRAPHX)
 static std::string BuildOptionsString(const onnxruntime::ProviderOptions::iterator& begin,
                                       const onnxruntime::ProviderOptions::iterator& end) {
   std::ostringstream options;
@@ -3170,3 +3179,125 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_VitisAI, _In_
   return nullptr;
   API_IMPL_END
 }
+
+ORT_API_STATUS_IMPL(OrtApis::CreateMIGraphXProviderOptions, _Outptr_ OrtMIGraphXProviderOptions** out) {
+  API_IMPL_BEGIN
+#ifdef USE_MIGRAPHX
+  auto migraphx_options = std::make_unique<OrtMIGraphXProviderOptions>();
+  memset(migraphx_options.get(), 0, sizeof(OrtMIGraphXProviderOptions));
+  *out = migraphx_options.release();
+  return nullptr;
+#else
+  ORT_UNUSED_PARAMETER(out);
+  return CreateStatus(ORT_FAIL, "MIGraphX execution provider is not enabled in this build.");
+#endif
+  API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(OrtApis::UpdateMIGraphXProviderOptions,
+                    _Inout_ OrtMIGraphXProviderOptions* migraphx_options,
+                    _In_reads_(num_keys) const char* const* provider_options_keys,
+                    _In_reads_(num_keys) const char* const* provider_options_values,
+                    size_t num_keys) {
+  API_IMPL_BEGIN
+#ifdef USE_MIGRAPHX
+  onnxruntime::ProviderOptions provider_options_map;
+  for (size_t i = 0; i != num_keys; ++i) {
+    if (provider_options_keys[i] == nullptr || provider_options_keys[i][0] == '\0' ||
+        provider_options_values[i] == nullptr || provider_options_values[i][0] == '\0') {
+      return OrtApis::CreateStatus(ORT_INVALID_ARGUMENT, "key/value cannot be empty");
+    }
+
+    provider_options_map[provider_options_keys[i]] = provider_options_values[i];
+  }
+
+  onnxruntime::s_library_migraphx.Get().UpdateProviderOptions(reinterpret_cast<void*>(migraphx_options), provider_options_map);
+  return nullptr;
+#else
+  ORT_UNUSED_PARAMETER(migraphx_options);
+  ORT_UNUSED_PARAMETER(provider_options_keys);
+  ORT_UNUSED_PARAMETER(provider_options_values);
+  ORT_UNUSED_PARAMETER(num_keys);
+  return CreateStatus(ORT_FAIL, "MIGraphX execution provider is not enabled in this build.");
+#endif
+  API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(OrtApis::GetMIGraphXProviderOptionsAsString,
+                    _In_ const OrtMIGraphXProviderOptions* migraphx_options,
+                    _Inout_ OrtAllocator* allocator,
+                    _Outptr_ char** ptr) {
+  API_IMPL_BEGIN
+#ifdef USE_MIGRAPHX
+  onnxruntime::ProviderOptions options =
+      onnxruntime::s_library_migraphx.Get().GetProviderOptions(reinterpret_cast<const void*>(migraphx_options));
+  std::string options_str = BuildOptionsString(options.begin(), options.end());
+  *ptr = onnxruntime::StrDup(options_str, allocator);
+  return nullptr;
+#else
+  ORT_UNUSED_PARAMETER(migraphx_options);
+  ORT_UNUSED_PARAMETER(allocator);
+  ORT_UNUSED_PARAMETER(ptr);
+  return CreateStatus(ORT_FAIL, "MIGraphX execution provider is not enabled in this build.");
+#endif
+  API_IMPL_END
+}
+
+ORT_API(void, OrtApis::ReleaseMIGraphXProviderOptions, _Frees_ptr_opt_ OrtMIGraphXProviderOptions* ptr) {
+#ifdef USE_MIGRAPHX
+  std::unique_ptr<OrtMIGraphXProviderOptions> p(ptr);
+  if(ptr->migraphx_cache_dir != nullptr) {
+    onnxruntime::AllocatorDefaultFree(const_cast<char*>(ptr->migraphx_cache_dir));
+  }
+#else
+  ORT_UNUSED_PARAMETER(ptr);
+#endif
+}
+
+ORT_API_STATUS_IMPL(OrtApis::UpdateMIGraphXProviderOptionsWithValue,
+                    _Inout_ OrtMIGraphXProviderOptions* migraphx_options,
+                    _In_ const char* key,
+                    _In_ void* value) {
+  API_IMPL_BEGIN
+#ifdef USE_MIGRAPHX
+  auto sv = std::string_view{key};
+  OrtAllocator* allocator;
+  GetAllocatorWithDefaultOptions(&allocator);
+  if (sv == onnxruntime::migraphx_provider_option::kDeviceId) {
+    auto dv = std::string_view{static_cast<char*>(value)};
+    if (std::from_chars(dv.data(), dv.data() + dv.length(), migraphx_options->device_id).ec == std::errc::invalid_argument) {
+      ORT_THROW("Cannot convert from string to integer - invalid argument");
+    }
+  } else
+  if (sv == onnxruntime::migraphx_provider_option::kModelCacheDir) {
+    auto sd = std::string_view{static_cast<char*>(value)};
+    migraphx_options->migraphx_cache_dir = onnxruntime::StrDup(sd.data(), allocator);
+  } else {
+    ORT_THROW("Unsupported provider option name: '" + std::string{sv} + "'");
+  }
+  return nullptr;
+#else
+  ORT_UNUSED_PARAMETER(migraphx_options);
+  ORT_UNUSED_PARAMETER(key);
+  ORT_UNUSED_PARAMETER(value);
+  return CreateStatus(ORT_FAIL, "MIGraphX execution provider is not enabled in this build.");
+#endif
+  API_IMPL_END
+}
+
+ORT_API_STATUS_IMPL(OrtApis::GetMIGraphXProviderOptionsByName,
+                    _In_ const OrtMIGraphXProviderOptions* migraphx_options,
+                    _In_ const char* key,
+                    _Outptr_ void** ptr) {
+  API_IMPL_BEGIN
+#ifdef USE_MIGRAPHX
+  return nullptr;
+#else
+  ORT_UNUSED_PARAMETER(cuda_options);
+  ORT_UNUSED_PARAMETER(key);
+  ORT_UNUSED_PARAMETER(ptr);
+  return CreateStatus(ORT_FAIL, "CUDA execution provider is not enabled in this build.");
+#endif
+  API_IMPL_END
+}
+

--- a/onnxruntime/core/session/provider_registration.cc
+++ b/onnxruntime/core/session/provider_registration.cc
@@ -101,6 +101,7 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider,
     VitisAI,
     CoreML,
     NvTensorRtRtx,  // TensorRt EP for RTX GPUs.
+    MIGraphX
   };
 
   struct EpToAppend {
@@ -109,7 +110,7 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider,
     const char* canonical_name = nullptr;
   };
 
-  static std::array<EpToAppend, 12> supported_eps = {
+  static std::array<EpToAppend, 13> supported_eps = {
       EpToAppend{EpID::DML, "DML", kDmlExecutionProvider},
       EpToAppend{EpID::QNN, "QNN", kQnnExecutionProvider},
       EpToAppend{EpID::OpenVINO, "OpenVINO", kOpenVINOExecutionProvider},
@@ -121,7 +122,9 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider,
       EpToAppend{EpID::JS, "JS", kJsExecutionProvider},
       EpToAppend{EpID::VitisAI, "VitisAI", kVitisAIExecutionProvider},
       EpToAppend{EpID::CoreML, "CoreML", kCoreMLExecutionProvider},
-      EpToAppend{EpID::NvTensorRtRtx, "NvTensorRtRtx", kNvTensorRTRTXExecutionProvider}};
+      EpToAppend{EpID::NvTensorRtRtx, "NvTensorRtRtx", kNvTensorRTRTXExecutionProvider},
+      EpToAppend{EpID::MIGraphX, "MIGraphX",kMIGraphXExecutionProvider}
+  };
 
   ProviderOptions provider_options;
   OrtStatus* status = ParseProviderOptions(provider_options_keys,
@@ -282,6 +285,14 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider,
 #endif
       break;
     }
+    case EpID::MIGraphX: {
+#if defined(USE_MIGRAPHX)
+      options->provider_factories.push_back(MIGraphXProviderFactoryCreator::Create(provider_options));
+#else
+      status = create_not_supported_status();
+#endif	
+	  break;
+	}
     case EpID::VitisAI: {
 #if defined(USE_VITISAI) || defined(USE_VITISAI_PROVIDER_INTERFACE)
       status = OrtApis::SessionOptionsAppendExecutionProvider_VitisAI(options, provider_options_keys,
@@ -657,4 +668,55 @@ ORT_API_STATUS_IMPL(OrtApis::SessionOptionsAppendExecutionProvider_VitisAI,
   ORT_UNUSED_PARAMETER(num_keys);
   return CreateNotEnabledStatus("VitisAI");
 }
+
+ORT_API_STATUS_IMPL(OrtApis::CreateMIGraphXProviderOptions, _Outptr_ OrtMIGraphXProviderOptions** out) {
+  ORT_UNUSED_PARAMETER(out);
+  return CreateNotEnabledStatus("MIGraphX");
+}
+
+ORT_API_STATUS_IMPL(OrtApis::UpdateMIGraphXProviderOptions,
+                    _Inout_ OrtMIGraphXProviderOptions* migraphx_options,
+                    _In_reads_(num_keys) const char* const* provider_options_keys,
+                    _In_reads_(num_keys) const char* const* provider_options_values,
+                    size_t num_keys) {
+  ORT_UNUSED_PARAMETER(migraphx_options);
+  ORT_UNUSED_PARAMETER(provider_options_keys);
+  ORT_UNUSED_PARAMETER(provider_options_values);
+  ORT_UNUSED_PARAMETER(num_keys);
+  return CreateNotEnabledStatus("MIGraphX");
+}
+
+ORT_API_STATUS_IMPL(OrtApis::GetMIGraphXProviderOptionsAsString,
+                    _In_ const OrtMIGraphXProviderOptions* migraphx_options, _Inout_ OrtAllocator* allocator,
+                    _Outptr_ char** ptr) {
+  ORT_UNUSED_PARAMETER(migraphx_options);
+  ORT_UNUSED_PARAMETER(allocator);
+  ORT_UNUSED_PARAMETER(ptr);
+  return CreateStatus(ORT_FAIL, "MIGraphX execution provider is not enabled in this build.");
+}
+
+ORT_API(void, OrtApis::ReleaseMIGraphXProviderOptions, _Frees_ptr_opt_ OrtMIGraphXProviderOptions* ptr) {
+  ORT_UNUSED_PARAMETER(ptr);
+}
+
+ORT_API_STATUS_IMPL(OrtApis::UpdateMIGraphXProviderOptionsWithValue,
+                    _Inout_ OrtMIGraphXProviderOptions* migraphx_options,
+                    _In_ const char* key,
+                    _In_ void* value) {
+  ORT_UNUSED_PARAMETER(migraphx_options);
+  ORT_UNUSED_PARAMETER(key);
+  ORT_UNUSED_PARAMETER(value);
+  return CreateNotEnabledStatus("MIGraphX");
+}
+
+ORT_API_STATUS_IMPL(OrtApis::GetMIGraphXProviderOptionsByName,
+                    _In_ const OrtMIGraphXProviderOptions* migraphx_options,
+                    _In_ const char* key,
+                    _Outptr_ void** ptr) {
+  ORT_UNUSED_PARAMETER(migraphx_options);
+  ORT_UNUSED_PARAMETER(key);
+  ORT_UNUSED_PARAMETER(ptr);
+  return CreateNotEnabledStatus("MIGraphX");
+}
+
 #endif

--- a/setup.py
+++ b/setup.py
@@ -410,6 +410,7 @@ else:
     libs.extend(["onnxruntime_providers_nv_tensorrt_rtx.dll"])
     libs.extend(["onnxruntime_providers_openvino.dll"])
     libs.extend(["onnxruntime_providers_cuda.dll"])
+    libs.extend(["onnxruntime_providers_migraphx.dll"])
     libs.extend(["onnxruntime_providers_vitisai.dll"])
     libs.extend(["onnxruntime_providers_qnn.dll"])
     # DirectML Libs

--- a/tools/ci_build/build.py
+++ b/tools/ci_build/build.py
@@ -1894,6 +1894,7 @@ def build_nuget_package(
     use_winml,
     use_qnn,
     use_dml,
+    use_migraphx,
     enable_training_apis,
     msbuild_extra_options,
 ):
@@ -1931,6 +1932,9 @@ def build_nuget_package(
     elif use_tensorrt:
         execution_provider = "/p:ExecutionProvider=tensorrt"
         package_name = "/p:OrtPackageId=Microsoft.ML.OnnxRuntime.TensorRT"
+    elif use_migraphx:
+        execution_provider = "/p:ExecutionProvider=migraphx"
+        package_name = "/p:OrtPackageId=Microsoft.ML.OnnxRuntime.MIGraphX"
     elif use_dnnl:
         execution_provider = "/p:ExecutionProvider=dnnl"
         package_name = "/p:OrtPackageId=Microsoft.ML.OnnxRuntime.DNNL"
@@ -2518,6 +2522,7 @@ def main():
                 getattr(args, "use_winml", False),
                 args.use_qnn,
                 getattr(args, "use_dml", False),
+                args.use_migraphx,
                 args.enable_training_apis,
                 normalize_arg_list(args.msbuild_extra_options),
             )

--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -44,7 +44,13 @@ def get_package_name(os, cpu_arch, ep, is_training_package):
 def is_this_file_needed(ep, filename, package_name):
     if package_name == "Microsoft.ML.OnnxRuntime.Gpu":
         return False
-    return (ep != "cuda" or "cuda" in filename) and (ep != "tensorrt" or "cuda" not in filename)
+    if package_name == "Microsoft.ML.OnnxRuntime.MIGraphX":
+        return False
+    return (
+        (ep != "cuda" or "cuda" in filename)
+        and (ep != "tensorrt" or "cuda" not in filename)
+        and (ep != "migraphx" or "migraphx" not in filename)
+    )
 
 
 # nuget_artifacts_dir: the directory with uncompressed C API tarball/zip files
@@ -64,7 +70,8 @@ def generate_file_list_for_ep(nuget_artifacts_dir, ep, files_list, include_pdbs,
                     if (
                         child_file.suffix in suffixes
                         and is_this_file_needed(ep, child_file.name, package_name)
-                        and package_name != "Microsoft.ML.OnnxRuntime.Gpu.Linux"
+                        and package_name not in ["Microsoft.ML.OnnxRuntime.Gpu.Linux",
+                                                 "Microsoft.ML.OnnxRuntime.MIGraphX.Linux"]
                     ):
                         files_list.append(
                             '<file src="' + str(child_file) + f'" target="runtimes/win-{cpu_arch}/native"/>'
@@ -95,6 +102,7 @@ def generate_file_list_for_ep(nuget_artifacts_dir, ep, files_list, include_pdbs,
                         child_file.suffix == ".so"
                         and is_this_file_needed(ep, child_file.name, package_name)
                         and package_name != "Microsoft.ML.OnnxRuntime.Gpu.Windows"
+                        and package_name != "Microsoft.ML.OnnxRuntime.MIGraphX.Windows"
                     ):
                         files_list.append(
                             '<file src="' + str(child_file) + f'" target="runtimes/linux-{cpu_arch}/native"/>'
@@ -138,7 +146,7 @@ def parse_arguments():
         required=False,
         default="None",
         type=str,
-        choices=["cuda", "dnnl", "openvino", "tensorrt", "snpe", "qnn", "None"],
+        choices=["cuda", "dnnl", "openvino", "migraphx", "tensorrt", "snpe", "qnn", "None"],
         help="The selected execution provider for this build.",
     )
     parser.add_argument("--sdk_info", required=False, default="", type=str, help="dependency SDK information.")
@@ -182,6 +190,10 @@ def generate_description(line_list, package_name):
         description = "This package contains Linux native shared library artifacts for ONNX Runtime with CUDA."
     elif "Microsoft.ML.OnnxRuntime.Gpu.Windows" in package_name:
         description = "This package contains Windows native shared library artifacts for ONNX Runtime with CUDA."
+    elif "Microsoft.ML.OnnxRuntime.MIGraphX.Linux" in package_name:
+        description = "This package contains Linux native shared library artifacts for ONNX Runtime with the MIGraphX."
+    elif "Microsoft.ML.OnnxRuntime.MIGraphX.Windows" in package_name:
+        description = "This package contains Windows native shared library artifacts for ONNX Runtime with the MIGraphX."
     elif "Intel.ML.OnnxRuntime" in package_name:
         description = "This package contains native shared library artifacts for ONNX Runtime with OpenVINO."
     elif "Microsoft.ML.OnnxRuntime" in package_name:  # This is a Microsoft.ML.OnnxRuntime.* package
@@ -224,6 +236,8 @@ def add_common_dependencies(xml_text, package_name, version):
     if package_name == "Microsoft.ML.OnnxRuntime.Gpu":
         xml_text.append('<dependency id="Microsoft.ML.OnnxRuntime.Gpu.Windows"' + ' version="' + version + '"/>')
         xml_text.append('<dependency id="Microsoft.ML.OnnxRuntime.Gpu.Linux"' + ' version="' + version + '"/>')
+    if package_name == "Microsoft.ML.OnnxRuntime.MIGraphX":
+        xml_text.append('<dependency id="Microsoft.ML.OnnxRuntime.MIGraphX.Windows"' + ' version="' + version + '"/>')
 
 
 def generate_dependencies(xml_text, package_name, version):
@@ -358,6 +372,9 @@ def generate_files(line_list, args):
     is_windowsai_package = args.package_name == "Microsoft.AI.MachineLearning"
     is_snpe_package = args.package_name == "Microsoft.ML.OnnxRuntime.Snpe"
     is_qnn_package = args.package_name == "Microsoft.ML.OnnxRuntime.QNN"
+    is_migraphx_package = args.package_name == "Microsoft.ML.OnnxRuntime.MIGraphX"
+    is_migraphx_win_sub_package = args.package_name == "Microsoft.ML.OnnxRuntime.MIGraphX.Windows"
+    is_migraphx_linux_sub_package = args.package_name == "Microsoft.ML.OnnxRuntime.MIGraphX.Linux"
     is_training_package = args.package_name in [
         "Microsoft.ML.OnnxRuntime.Training",
         "Microsoft.ML.OnnxRuntime.Training.Gpu",
@@ -383,6 +400,7 @@ def generate_files(line_list, args):
             "openvino_ep_shared_lib": "onnxruntime_providers_openvino.dll",
             "cuda_ep_shared_lib": "onnxruntime_providers_cuda.dll",
             "qnn_ep_shared_lib": "onnxruntime_providers_qnn.dll",
+            "migraphx_ep_shared_lib": "onnxruntime_providers_migraphx.dll",
             "onnxruntime_perf_test": "onnxruntime_perf_test.exe",
             "onnx_test_runner": "onnx_test_runner.exe",
         }
@@ -420,7 +438,7 @@ def generate_files(line_list, args):
     include_dir = f"{build_dir}\\native\\include"
 
     # Sub.Gpu packages do not include the onnxruntime headers
-    if args.package_name != "Microsoft.ML.OnnxRuntime.Gpu":
+    if args.package_name != "Microsoft.ML.OnnxRuntime.Gpu" and args.package_name != "Microsoft.ML.OnnxRuntime.MIGraphX":
         files_list.append(
             "<file src="
             + '"'
@@ -580,6 +598,8 @@ def generate_files(line_list, args):
                 ep_list = ["tensorrt", "cuda", None]
             elif is_rocm_gpu_package:
                 ep_list = ["rocm", None]
+            elif is_migraphx_package or is_migraphx_win_sub_package or is_migraphx_linux_sub_package:
+                ep_list = ["migraphx", None]
             else:
                 ep_list = [None]
             for ep in ep_list:
@@ -794,8 +814,26 @@ def generate_files(line_list, args):
             + '\\native" />'
         )
 
+    if args.execution_provider == "migraphx" or (is_migraphx_win_sub_package and not is_ado_packaging_build):
+        files_list.append(
+            "<file src="
+            + '"'
+            + os.path.join(args.native_build_path, nuget_dependencies["providers_shared_lib"])
+            + runtimes_target
+            + args.target_architecture
+            + '\\native" />'
+        )
+        files_list.append(
+            "<file src="
+            + '"'
+            + os.path.join(args.native_build_path, nuget_dependencies["migraphx_ep_shared_lib"])
+            + runtimes_target
+            + args.target_architecture
+            + '\\native" />'
+        )
+
     # process all other library dependencies
-    if is_cpu_package or is_cuda_gpu_package or is_dml_package or is_mklml_package:
+    if is_cpu_package or is_cuda_gpu_package or is_migraphx_package or is_dml_package or is_mklml_package:
         # Process dnnl dependency
         if os.path.exists(os.path.join(args.native_build_path, nuget_dependencies["dnnl"])):
             files_list.append(
@@ -898,6 +936,9 @@ def generate_files(line_list, args):
         or is_cuda_gpu_linux_sub_package
         or is_cuda_gpu_win_sub_package
         or is_rocm_gpu_package
+        or is_migraphx_package
+        or is_migraphx_linux_sub_package
+        or is_migraphx_win_sub_package
         or is_dml_package
         or is_mklml_package
         or is_snpe_package


### PR DESCRIPTION
Amuse requires the changes from this PR for running inference with MIGraphX EP.

The base C# interface for MIGraphX execution provider. It allows creating a C# ONNXRT session with MIGraphX EP and running inference with it. It has minimal support for MIGraphX EP provider options, which means the application can only specify the `device_id` and MXR cache directory when creating a session. Future PRs will extend the range of available MIGraphX EP provider options for C# applications, while maintaining the functionality of all other C# interface features.